### PR TITLE
Add status code mapping (statusToPhrase, statusToSlug)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ export type {
 	ProblemDetailsHandlerOptions,
 	ProblemDetailsInput,
 } from "./types.js";
+export { statusToPhrase, statusToSlug } from "./status.js";

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,0 +1,32 @@
+const STATUS_PHRASES: Record<number, string> = {
+	400: "Bad Request",
+	401: "Unauthorized",
+	403: "Forbidden",
+	404: "Not Found",
+	405: "Method Not Allowed",
+	406: "Not Acceptable",
+	408: "Request Timeout",
+	409: "Conflict",
+	410: "Gone",
+	411: "Length Required",
+	412: "Precondition Failed",
+	413: "Content Too Large",
+	415: "Unsupported Media Type",
+	422: "Unprocessable Content",
+	429: "Too Many Requests",
+	500: "Internal Server Error",
+	501: "Not Implemented",
+	502: "Bad Gateway",
+	503: "Service Unavailable",
+	504: "Gateway Timeout",
+};
+
+export function statusToPhrase(status: number): string | undefined {
+	return STATUS_PHRASES[status];
+}
+
+export function statusToSlug(status: number): string | undefined {
+	const phrase = STATUS_PHRASES[status];
+	if (!phrase) return undefined;
+	return phrase.toLowerCase().replace(/ /g, "-");
+}

--- a/tests/status.test.ts
+++ b/tests/status.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { statusToPhrase, statusToSlug } from "../src/status.js";
+
+describe("statusToPhrase", () => {
+	it.each([
+		[400, "Bad Request"],
+		[401, "Unauthorized"],
+		[403, "Forbidden"],
+		[404, "Not Found"],
+		[409, "Conflict"],
+		[422, "Unprocessable Content"],
+		[429, "Too Many Requests"],
+		[500, "Internal Server Error"],
+		[502, "Bad Gateway"],
+		[503, "Service Unavailable"],
+	])("returns %j for status %d", (status, expected) => {
+		expect(statusToPhrase(status)).toBe(expected);
+	});
+
+	it("returns undefined for unknown status code", () => {
+		expect(statusToPhrase(999)).toBeUndefined();
+	});
+});
+
+describe("statusToSlug", () => {
+	it.each([
+		[400, "bad-request"],
+		[401, "unauthorized"],
+		[403, "forbidden"],
+		[404, "not-found"],
+		[409, "conflict"],
+		[422, "unprocessable-content"],
+		[429, "too-many-requests"],
+		[500, "internal-server-error"],
+		[502, "bad-gateway"],
+		[503, "service-unavailable"],
+	])("returns %j for status %d", (status, expected) => {
+		expect(statusToSlug(status)).toBe(expected);
+	});
+
+	it("returns undefined for unknown status code", () => {
+		expect(statusToSlug(999)).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary
- Add `statusToPhrase()` and `statusToSlug()` utilities in `src/status.ts`
- 20 common HTTP status codes mapped (IANA registry)
- TDD: 22 tests covering phrase mapping, slug generation, and unknown codes

## Test plan
- [x] 22 tests pass (`pnpm vitest run tests/status.test.ts`)
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm build` succeeds

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)