### PR TITLE
Add problemDetailsHandler for app.onError

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,4 @@ export type {
 export { statusToPhrase, statusToSlug } from "./status.js";
 export { ProblemDetailsError } from "./error.js";
 export { problemDetails } from "./factory.js";
+export { problemDetailsHandler } from "./handler.js";


### PR DESCRIPTION
## Summary
- Add `problemDetailsHandler()` error handler for `app.onError`
- Handles ProblemDetailsError (as-is), HTTPException (auto-convert), and generic Error (500)
- Options: typePrefix, defaultType, includeStack, mapError
- Sets `c.get('problemDetails')` on Hono context for downstream middleware
- 100% test coverage (13 tests, all metrics)

## Test plan
- [x] 42 tests pass (22 status + 7 factory + 13 handler)
- [x] 100% coverage on statements/branches/functions/lines
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm build` succeeds

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)