### PR TITLE
Add type inference tests for public types

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -55,105 +55,53 @@
 
 ### 1.5 Status Code Mapping
 
-TDD: write `tests/status.test.ts` first
-
-- [ ] `src/status.ts` — statusToPhrase(), statusToSlug()
-- [ ] Tests:
-  - Common status codes (400, 401, 403, 404, 409, 422, 429, 500, 502, 503) → phrase
-  - Unknown status code → undefined
-  - Slug generation (422 → "unprocessable-content")
+- [x] `src/status.ts` — statusToPhrase(), statusToSlug()
+- [x] Tests (22 tests): common status codes, unknown status, slug generation
 
 ### 1.6 ProblemDetailsError
 
-TDD: write `tests/factory.test.ts` first
-
-- [ ] `src/error.ts` — ProblemDetailsError class
-- [ ] `src/factory.ts` — problemDetails() factory function
-- [ ] Tests:
-  | # | Test Case | Expected | Priority |
-  |---|-----------|----------|----------|
-  | F1 | Minimal input (status only) | type="about:blank", title=auto, detail=undefined | **Required** |
-  | F2 | All fields specified | specified values used as-is | **Required** |
-  | F3 | With extension members | extensions flattened to top level | **Required** |
-  | F4 | getResponse() | Content-Type: application/problem+json, JSON body | **Required** |
-  | F5 | status matches response status | RFC 9457 MUST requirement | **Required** |
-  | F6 | Extends Error | instanceof Error is true | **Required** |
+- [x] `src/error.ts` — ProblemDetailsError class
+- [x] `src/factory.ts` — problemDetails() factory function
+- [x] Tests (7 tests): F1-F6 + unknown status fallback
 
 ### 1.7 Error Handler
 
-TDD: write `tests/handler.test.ts` first
-
-- [ ] `src/handler.ts` — problemDetailsHandler()
-- [ ] Tests:
-  | # | Test Case | Expected | Priority |
-  |---|-----------|----------|----------|
-  | H1 | ProblemDetailsError thrown | Problem Details response as-is | **Required** |
-  | H2 | HTTPException thrown | Auto-convert to Problem Details | **Required** |
-  | H3 | Generic Error thrown | 500 + Problem Details | **Required** |
-  | H4 | typePrefix set | type = `{prefix}/{slug}` | **Required** |
-  | H5 | typePrefix not set | type = "about:blank" | **Required** |
-  | H6 | includeStack: true | stack trace in detail | Medium |
-  | H7 | includeStack: false (default) | no stack trace in detail | **Required** |
-  | H8 | mapError custom mapping | custom result returned | **Required** |
-  | H9 | mapError returns undefined | fallback to default handling | **Required** |
-  | H10 | Content-Type header | "application/problem+json" | **Required** |
-  | H11 | c.get('problemDetails') is set | accessible from context | Medium |
+- [x] `src/handler.ts` — problemDetailsHandler()
+- [x] Tests (13 tests): H1-H11 + defaultType + unknown status via mapError
 
 ## Phase 2: Validator Integration
 
 ### 2.1 zodProblemHook
 
-TDD: write `tests/integrations/zod.test.ts` first
-
-- [ ] `src/integrations/zod.ts` — zodProblemHook()
-- [ ] Tests:
-  | # | Test Case | Expected | Priority |
-  |---|-----------|----------|----------|
-  | Z1 | Validation success | hook returns nothing (void) | **Required** |
-  | Z2 | Single field error | 422 + errors array with 1 item | **Required** |
-  | Z3 | Multiple field errors | 422 + errors array with multiple items | **Required** |
-  | Z4 | Nested field error | field as "address.city" (dot-separated) | **Required** |
-  | Z5 | Content-Type | "application/problem+json" | **Required** |
-  | Z6 | errors extension member structure | { field, message, code } | **Required** |
-  | Z7 | Custom title/detail options | zodProblemHook({ title: '...' }) overrides | Medium |
+- [x] `src/integrations/zod.ts` — zodProblemHook()
+- [x] Tests (7 tests): Z1-Z7
 
 ### 2.2 valibotProblemHook
 
-TDD: write `tests/integrations/valibot.test.ts` first
-
-- [ ] `src/integrations/valibot.ts` — valibotProblemHook()
-- [ ] Subpath export: `./valibot`
-- [ ] Tests:
-  | # | Test Case | Expected | Priority |
-  |---|-----------|----------|----------|
-  | V1 | Validation success | hook returns nothing (void) | **Required** |
-  | V2 | Single field error | 422 + errors array with 1 item | **Required** |
-  | V3 | Multiple field errors | 422 + errors array with multiple items | **Required** |
-  | V4 | Nested field error | field as "address.city" (dot-separated) | **Required** |
-  | V5 | Content-Type | "application/problem+json" | **Required** |
-  | V6 | errors extension member structure | { field, message, code } | **Required** |
-  | V7 | Custom title/detail options | valibotProblemHook({ title: '...' }) overrides | Medium |
+- [x] `src/integrations/valibot.ts` — valibotProblemHook()
+- [x] Subpath export: `./valibot`
+- [x] Tests (8 tests): V1-V7 + root-level validation without path
 
 ## Phase 3: Community & Docs
 
 ### 3.1 Community Files
 
-- [ ] CONTRIBUTING.md — dev setup, commands, TDD workflow, code style (biome), changeset usage
-- [ ] CODE_OF_CONDUCT.md — Contributor Covenant v2.1
-- [ ] SECURITY.md — supported versions, report via GitHub Security Advisories, response timeline
-- [ ] LICENSE (MIT)
+- [x] CONTRIBUTING.md — dev setup, commands, TDD workflow, code style (biome), changeset usage
+- [x] CODE_OF_CONDUCT.md — Contributor Covenant v2.1
+- [x] SECURITY.md — supported versions, report via GitHub Security Advisories, response timeline
+- [x] LICENSE (MIT)
 
 ### 3.2 GitHub Templates
 
-- [ ] `.github/FUNDING.yml`
-- [ ] `.github/ISSUE_TEMPLATE/bug_report.yml` — version, Hono version, runtime, reproduction steps
-- [ ] `.github/ISSUE_TEMPLATE/feature_request.yml` — problem, proposed solution, alternatives
-- [ ] `.github/PULL_REQUEST_TEMPLATE.md` — Summary, Related Issues, checklist (tests/typecheck/lint/changeset)
+- [x] `.github/FUNDING.yml`
+- [x] `.github/ISSUE_TEMPLATE/bug_report.yml` — version, Hono version, runtime, reproduction steps
+- [x] `.github/ISSUE_TEMPLATE/feature_request.yml` — problem, proposed solution, alternatives
+- [x] `.github/PULL_REQUEST_TEMPLATE.md` — Summary, Related Issues, checklist (tests/typecheck/lint/changeset)
 
 ### 3.3 Packaging
 
-- [ ] README.md (English) — RFC 9457 compliance, usage examples, Zod/Valibot integration
-- [ ] Subpath exports (`.` → core, `./zod` → Zod, `./valibot` → Valibot)
+- [x] README.md (English) — RFC 9457 compliance, usage examples, Zod/Valibot integration
+- [x] Subpath exports (`.` → core, `./zod` → Zod, `./valibot` → Valibot)
 - [ ] npm publish + JSR publish
 - [ ] CHANGELOG.md — auto-generated by changesets
 

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -1,0 +1,97 @@
+import { describe, expectTypeOf, it } from "vitest";
+import type { ProblemDetailsError } from "../src/error.js";
+import { problemDetails } from "../src/factory.js";
+import type {
+	ProblemDetails,
+	ProblemDetailsHandlerOptions,
+	ProblemDetailsInput,
+} from "../src/types.js";
+
+describe("ProblemDetails type", () => {
+	it("has required fields type, status, title", () => {
+		expectTypeOf<ProblemDetails>().toHaveProperty("type");
+		expectTypeOf<ProblemDetails>().toHaveProperty("status");
+		expectTypeOf<ProblemDetails>().toHaveProperty("title");
+		expectTypeOf<ProblemDetails["type"]>().toEqualTypeOf<string>();
+		expectTypeOf<ProblemDetails["status"]>().toEqualTypeOf<number>();
+		expectTypeOf<ProblemDetails["title"]>().toEqualTypeOf<string>();
+	});
+
+	it("has optional fields detail, instance", () => {
+		expectTypeOf<ProblemDetails["detail"]>().toEqualTypeOf<string | undefined>();
+		expectTypeOf<ProblemDetails["instance"]>().toEqualTypeOf<string | undefined>();
+	});
+
+	it("generic parameter types extensions", () => {
+		type CustomExt = { traceId: string; retryAfter: number };
+		type PD = ProblemDetails<CustomExt>;
+		expectTypeOf<PD["extensions"]>().toEqualTypeOf<CustomExt | undefined>();
+	});
+
+	it("default generic parameter is Record<string, unknown>", () => {
+		expectTypeOf<ProblemDetails["extensions"]>().toEqualTypeOf<
+			Record<string, unknown> | undefined
+		>();
+	});
+});
+
+describe("ProblemDetailsInput type", () => {
+	it("requires status only", () => {
+		expectTypeOf<{ status: number }>().toMatchTypeOf<ProblemDetailsInput>();
+	});
+
+	it("type, title, detail, instance are optional", () => {
+		expectTypeOf<ProblemDetailsInput["type"]>().toEqualTypeOf<string | undefined>();
+		expectTypeOf<ProblemDetailsInput["title"]>().toEqualTypeOf<string | undefined>();
+		expectTypeOf<ProblemDetailsInput["detail"]>().toEqualTypeOf<string | undefined>();
+		expectTypeOf<ProblemDetailsInput["instance"]>().toEqualTypeOf<string | undefined>();
+	});
+
+	it("generic parameter types extensions", () => {
+		type CustomExt = { errors: string[] };
+		type Input = ProblemDetailsInput<CustomExt>;
+		expectTypeOf<Input["extensions"]>().toEqualTypeOf<CustomExt | undefined>();
+	});
+});
+
+describe("ProblemDetailsHandlerOptions type", () => {
+	it("all fields are optional", () => {
+		// biome-ignore lint/complexity/noBannedTypes: testing that empty object satisfies the type
+		expectTypeOf<{}>().toMatchTypeOf<ProblemDetailsHandlerOptions>();
+	});
+
+	it("mapError accepts Error and returns ProblemDetailsInput or undefined", () => {
+		expectTypeOf<ProblemDetailsHandlerOptions["mapError"]>().toEqualTypeOf<
+			((error: Error) => ProblemDetailsInput | undefined) | undefined
+		>();
+	});
+});
+
+describe("problemDetails() factory type inference", () => {
+	it("returns ProblemDetailsError", () => {
+		const err = problemDetails({ status: 404 });
+		expectTypeOf(err).toEqualTypeOf<ProblemDetailsError>();
+	});
+
+	it("accepts typed extensions", () => {
+		const err = problemDetails({
+			status: 422,
+			extensions: { errors: [{ field: "email", message: "invalid" }] },
+		});
+		expectTypeOf(err).toEqualTypeOf<ProblemDetailsError>();
+	});
+});
+
+describe("ProblemDetailsError type", () => {
+	it("extends Error", () => {
+		expectTypeOf<ProblemDetailsError>().toMatchTypeOf<Error>();
+	});
+
+	it("has readonly problemDetails property", () => {
+		expectTypeOf<ProblemDetailsError["problemDetails"]>().toEqualTypeOf<ProblemDetails>();
+	});
+
+	it("getResponse returns Response", () => {
+		expectTypeOf<ProblemDetailsError["getResponse"]>().toEqualTypeOf<() => Response>();
+	});
+});


### PR DESCRIPTION
## Summary

- Add 14 type-level tests using vitest `expectTypeOf` for all public types
- Verify `ProblemDetails<T>` generic parameter inference and extension typing
- Verify `ProblemDetailsInput<T>` required/optional field types
- Verify `ProblemDetailsHandlerOptions` all-optional pattern
- Verify `problemDetails()` factory return type
- Verify `ProblemDetailsError` extends Error with correct property types
- Update docs/TODO.md to reflect all completed Phase 1-3 items

Closes #16

## Test plan

- [x] `pnpm test` passes (71 tests)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)