### PR TITLE
Prepare initial release (changeset, JSR, keywords)

### DIFF
--- a/.changeset/initial-release.md
+++ b/.changeset/initial-release.md
@@ -1,0 +1,13 @@
+---
+"hono-problem-details": minor
+---
+
+Initial release of hono-problem-details
+
+- RFC 9457 Problem Details middleware for Hono
+- `problemDetailsHandler()` for `app.onError`
+- `problemDetails()` factory and `ProblemDetailsError` class
+- Zod validator integration (`hono-problem-details/zod`)
+- Valibot validator integration (`hono-problem-details/valibot`)
+- OpenAPI integration (`hono-problem-details/openapi`)
+- 100% test coverage (86 tests)

--- a/jsr.json
+++ b/jsr.json
@@ -1,0 +1,13 @@
+{
+	"name": "@paveg/hono-problem-details",
+	"version": "0.0.0",
+	"exports": {
+		".": "./src/index.ts",
+		"./zod": "./src/integrations/zod.ts",
+		"./valibot": "./src/integrations/valibot.ts",
+		"./openapi": "./src/integrations/openapi.ts"
+	},
+	"publish": {
+		"include": ["src", "LICENSE", "README.md", "jsr.json"]
+	}
+}

--- a/package.json
+++ b/package.json
@@ -61,7 +61,17 @@
 		"release": "pnpm build && changeset publish",
 		"version-packages": "changeset version && pnpm lint:fix"
 	},
-	"keywords": ["hono", "rfc9457", "problem-details", "error-handling", "middleware", "api"],
+	"keywords": [
+		"hono",
+		"rfc9457",
+		"problem-details",
+		"error-handling",
+		"middleware",
+		"api",
+		"openapi",
+		"zod",
+		"valibot"
+	],
 	"license": "MIT",
 	"peerDependencies": {
 		"hono": ">=4.0.0"


### PR DESCRIPTION
## Summary

- Add changeset for initial v0.1.0 minor release
- Add `jsr.json` for JSR publishing with all 4 subpath exports (`.`, `./zod`, `./valibot`, `./openapi`)
- Add `openapi`, `zod`, `valibot` to package.json keywords for npm discoverability

Closes #20

## Test plan

- [x] `pnpm test` passes (86 tests)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)