### PR TITLE
Add Standard Schema validator integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Returns `application/problem+json` structured error responses with a single `app
 - **Zod integration** — `@hono/zod-validator` hook for validation errors
 - **Valibot integration** — `@hono/valibot-validator` hook for validation errors
 - **OpenAPI integration** — `@hono/zod-openapi` schemas for API documentation
+- **Standard Schema** — `@hono/standard-validator` hook (works with any schema library)
 - **Type-safe** — full TypeScript support with inference
 - **Zero external dependencies** — only `hono` as peer dependency
 - **Edge-first** — works on Cloudflare Workers, Deno, Bun, and Node.js
@@ -128,6 +129,25 @@ const schema = v.object({
 });
 
 app.post("/users", vValidator("json", schema, valibotProblemHook()), (c) => {
+  const data = c.req.valid("json");
+  // ...
+});
+```
+
+## Standard Schema Integration
+
+Works with any [Standard Schema](https://standardschema.dev/) compatible library (Zod, Valibot, ArkType, etc.):
+
+```ts
+import { sValidator } from "@hono/standard-validator";
+import { standardSchemaProblemHook } from "hono-problem-details/standard-schema";
+import { z } from "zod"; // or valibot, arktype, etc.
+
+const schema = z.object({
+  email: z.string().email(),
+});
+
+app.post("/users", sValidator("json", schema, standardSchemaProblemHook()), (c) => {
   const data = c.req.valid("json");
   // ...
 });

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -206,7 +206,7 @@ This is correct. Call `getResponse()` inside middleware to return directly. No d
 ## Stretch Goals
 
 - [x] OpenAPI integration (`hono-problem-details/openapi`) — ProblemDetailsSchema, createProblemDetailsSchema, problemDetailsResponse for @hono/zod-openapi
-- [ ] Standard Schema integration (`hono-problem-details/standard-schema`) — ArkType support
+- [x] Standard Schema integration (`hono-problem-details/standard-schema`) — standardSchemaProblemHook for @hono/standard-validator
 - [ ] i18n — title/detail localization
 - [ ] Problem type registry — helpers for defining/managing custom problem types
 - [ ] Express adapter — alternative to express-http-problem-details

--- a/jsr.json
+++ b/jsr.json
@@ -5,7 +5,8 @@
 		".": "./src/index.ts",
 		"./zod": "./src/integrations/zod.ts",
 		"./valibot": "./src/integrations/valibot.ts",
-		"./openapi": "./src/integrations/openapi.ts"
+		"./openapi": "./src/integrations/openapi.ts",
+		"./standard-schema": "./src/integrations/standard-schema.ts"
 	},
 	"publish": {
 		"include": ["src", "LICENSE", "README.md", "jsr.json"]

--- a/package.json
+++ b/package.json
@@ -46,6 +46,16 @@
 				"types": "./dist/integrations/openapi.d.cts",
 				"default": "./dist/integrations/openapi.cjs"
 			}
+		},
+		"./standard-schema": {
+			"import": {
+				"types": "./dist/integrations/standard-schema.d.ts",
+				"default": "./dist/integrations/standard-schema.js"
+			},
+			"require": {
+				"types": "./dist/integrations/standard-schema.d.cts",
+				"default": "./dist/integrations/standard-schema.cjs"
+			}
 		}
 	},
 	"files": ["dist"],
@@ -91,15 +101,23 @@
 		},
 		"@hono/zod-openapi": {
 			"optional": true
+		},
+		"@hono/standard-validator": {
+			"optional": true
+		},
+		"@standard-schema/spec": {
+			"optional": true
 		}
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.0",
 		"@changesets/changelog-github": "0.5.2",
 		"@changesets/cli": "2.29.8",
+		"@hono/standard-validator": "0.2.2",
 		"@hono/valibot-validator": "^0.5.0",
 		"@hono/zod-openapi": "0.19.10",
 		"@hono/zod-validator": "^0.5.0",
+		"@standard-schema/spec": "1.1.0",
 		"@vitest/coverage-v8": "^3.0.0",
 		"hono": "^4.7.0",
 		"lefthook": "2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@changesets/cli':
         specifier: 2.29.8
         version: 2.29.8
+      '@hono/standard-validator':
+        specifier: 0.2.2
+        version: 0.2.2(@standard-schema/spec@1.1.0)(hono@4.12.2)
       '@hono/valibot-validator':
         specifier: ^0.5.0
         version: 0.5.3(hono@4.12.2)(valibot@1.2.0(typescript@5.9.3))
@@ -26,6 +29,9 @@ importers:
       '@hono/zod-validator':
         specifier: ^0.5.0
         version: 0.5.0(hono@4.12.2)(zod@3.25.76)
+      '@standard-schema/spec':
+        specifier: 1.1.0
+        version: 1.1.0
       '@vitest/coverage-v8':
         specifier: ^3.0.0
         version: 3.2.4(vitest@3.2.4(yaml@2.8.2))
@@ -357,6 +363,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@hono/standard-validator@0.2.2':
+    resolution: {integrity: sha512-mJ7W84Bt/rSvoIl63Ynew+UZOHAzzRAoAXb3JaWuxAkM/Lzg+ZHTCUiz77KOtn2e623WNN8LkD57Dk0szqUrIw==}
+    peerDependencies:
+      '@standard-schema/spec': ^1.0.0
+      hono: '>=3.9.0'
+
   '@hono/valibot-validator@0.5.3':
     resolution: {integrity: sha512-91wjmjDvrTdEm2ZcuCyLBghtld78QoLEduzfkqLo1L74n6sqqoVfc0gDfmju1Ar6w1eK8Q0UyIubrtj4KMWVnQ==}
     peerDependencies:
@@ -558,6 +570,9 @@ packages:
     resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
     cpu: [x64]
     os: [win32]
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -1783,6 +1798,11 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
+  '@hono/standard-validator@0.2.2(@standard-schema/spec@1.1.0)(hono@4.12.2)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      hono: 4.12.2
+
   '@hono/valibot-validator@0.5.3(hono@4.12.2)(valibot@1.2.0(typescript@5.9.3))':
     dependencies:
       hono: 4.12.2
@@ -1941,6 +1961,8 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@types/chai@5.2.3':
     dependencies:

--- a/src/integrations/standard-schema.ts
+++ b/src/integrations/standard-schema.ts
@@ -1,0 +1,49 @@
+import type { StandardSchemaV1 } from "@standard-schema/spec";
+import type { Context } from "hono";
+
+export interface StandardSchemaProblemHookOptions {
+	title?: string;
+	detail?: string;
+}
+
+interface ValidationError {
+	field: string;
+	message: string;
+}
+
+function formatPath(path: ReadonlyArray<PropertyKey | StandardSchemaV1.PathSegment>): string {
+	return path
+		.map((segment) => (typeof segment === "object" ? String(segment.key) : String(segment)))
+		.join(".");
+}
+
+function formatIssues(issues: readonly StandardSchemaV1.Issue[]): ValidationError[] {
+	return issues.map((issue) => ({
+		field: issue.path ? formatPath(issue.path) : "",
+		message: issue.message,
+	}));
+}
+
+export function standardSchemaProblemHook(options?: StandardSchemaProblemHookOptions) {
+	return (
+		result:
+			| { success: true; data: unknown }
+			| { success: false; error: readonly StandardSchemaV1.Issue[] },
+		c: Context,
+	) => {
+		if (result.success) return;
+
+		const body = {
+			type: "about:blank",
+			status: 422,
+			title: options?.title ?? "Validation Error",
+			detail: options?.detail ?? "Request validation failed",
+			errors: formatIssues(result.error),
+		};
+
+		return new Response(JSON.stringify(body), {
+			status: 422,
+			headers: { "Content-Type": "application/problem+json" },
+		});
+	};
+}

--- a/tests/integrations/standard-schema.test.ts
+++ b/tests/integrations/standard-schema.test.ts
@@ -1,0 +1,158 @@
+import { sValidator } from "@hono/standard-validator";
+import { Hono } from "hono";
+import * as v from "valibot";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { standardSchemaProblemHook } from "../../src/integrations/standard-schema.js";
+
+describe("standardSchemaProblemHook", () => {
+	it("S1: returns nothing on success (Zod)", async () => {
+		const app = new Hono();
+		const schema = z.object({ name: z.string() });
+
+		app.post("/test", sValidator("json", schema, standardSchemaProblemHook()), (c) => {
+			return c.json({ ok: true });
+		});
+
+		const res = await app.request("/test", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ name: "test" }),
+		});
+		expect(res.status).toBe(200);
+	});
+
+	it("S2: returns 422 with errors on single field error (Zod)", async () => {
+		const app = new Hono();
+		const schema = z.object({ email: z.string().email() });
+
+		app.post("/test", sValidator("json", schema, standardSchemaProblemHook()), (c) => {
+			return c.json({ ok: true });
+		});
+
+		const res = await app.request("/test", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ email: "invalid" }),
+		});
+		expect(res.status).toBe(422);
+		expect(res.headers.get("Content-Type")).toContain("application/problem+json");
+
+		const body = await res.json();
+		expect(body.type).toBe("about:blank");
+		expect(body.status).toBe(422);
+		expect(body.title).toBe("Validation Error");
+		expect(body.detail).toBe("Request validation failed");
+		expect(body.errors).toHaveLength(1);
+		expect(body.errors[0].field).toBe("email");
+		expect(body.errors[0].message).toBeDefined();
+	});
+
+	it("S3: returns multiple errors (Zod)", async () => {
+		const app = new Hono();
+		const schema = z.object({
+			email: z.string().email(),
+			age: z.number().positive(),
+		});
+
+		app.post("/test", sValidator("json", schema, standardSchemaProblemHook()), (c) => {
+			return c.json({ ok: true });
+		});
+
+		const res = await app.request("/test", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ email: "bad", age: -1 }),
+		});
+		const body = await res.json();
+		expect(body.errors.length).toBeGreaterThanOrEqual(2);
+	});
+
+	it("S4: handles nested field paths (Valibot)", async () => {
+		const app = new Hono();
+		const schema = v.object({
+			address: v.object({
+				city: v.pipe(v.string(), v.minLength(1)),
+			}),
+		});
+
+		app.post("/test", sValidator("json", schema, standardSchemaProblemHook()), (c) => {
+			return c.json({ ok: true });
+		});
+
+		const res = await app.request("/test", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ address: { city: "" } }),
+		});
+		const body = await res.json();
+		expect(body.errors[0].field).toBe("address.city");
+	});
+
+	it("S5: works with Valibot schemas", async () => {
+		const app = new Hono();
+		const schema = v.object({
+			name: v.pipe(v.string(), v.minLength(1)),
+		});
+
+		app.post("/test", sValidator("json", schema, standardSchemaProblemHook()), (c) => {
+			return c.json({ ok: true });
+		});
+
+		const res = await app.request("/test", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ name: "" }),
+		});
+		expect(res.status).toBe(422);
+		const body = await res.json();
+		expect(body.errors).toHaveLength(1);
+	});
+
+	it("S6: custom title and detail options", async () => {
+		const app = new Hono();
+		const schema = z.object({ name: z.string() });
+
+		app.post(
+			"/test",
+			sValidator(
+				"json",
+				schema,
+				standardSchemaProblemHook({
+					title: "Bad Input",
+					detail: "Please check your data",
+				}),
+			),
+			(c) => c.json({ ok: true }),
+		);
+
+		const res = await app.request("/test", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ name: 42 }),
+		});
+		const body = await res.json();
+		expect(body.title).toBe("Bad Input");
+		expect(body.detail).toBe("Please check your data");
+	});
+
+	it("S7: handles errors without path", async () => {
+		const app = new Hono();
+		const schema = v.pipe(
+			v.object({ a: v.string() }),
+			v.check(() => false, "root error"),
+		);
+
+		app.post("/test", sValidator("json", schema, standardSchemaProblemHook()), (c) => {
+			return c.json({ ok: true });
+		});
+
+		const res = await app.request("/test", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ a: "ok" }),
+		});
+		const body = await res.json();
+		expect(body.errors[0].field).toBe("");
+	});
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
 		"integrations/zod": "src/integrations/zod.ts",
 		"integrations/valibot": "src/integrations/valibot.ts",
 		"integrations/openapi": "src/integrations/openapi.ts",
+		"integrations/standard-schema": "src/integrations/standard-schema.ts",
 	},
 	format: ["esm", "cjs"],
 	dts: true,
@@ -18,5 +19,7 @@ export default defineConfig({
 		"@hono/zod-validator",
 		"@hono/valibot-validator",
 		"valibot",
+		"@hono/standard-validator",
+		"@standard-schema/spec",
 	],
 });


### PR DESCRIPTION
## Summary

- Add `hono-problem-details/standard-schema` subpath export
- `standardSchemaProblemHook()` for `@hono/standard-validator`
- Works with any Standard Schema-compatible library (Zod, Valibot, ArkType, etc.)
- 7 tests with 100% coverage
- Updated README, TODO, jsr.json, tsup.config.ts, package.json

Closes #22

## Test plan

- [x] `pnpm test` passes (93 tests)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)