### PR TITLE
Add problem type registry for type-safe error creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,40 @@ throw problemDetails({
 // }
 ```
 
+## Problem Type Registry
+
+Pre-define your API's error types for type-safe error creation:
+
+```ts
+import { createProblemTypeRegistry } from "hono-problem-details";
+
+const problems = createProblemTypeRegistry({
+  ORDER_CONFLICT: {
+    type: "https://api.example.com/problems/order-conflict",
+    status: 409,
+    title: "Order Conflict",
+  },
+  RATE_LIMITED: {
+    type: "https://api.example.com/problems/rate-limited",
+    status: 429,
+    title: "Too Many Requests",
+  },
+});
+
+// Type-safe error creation
+app.post("/orders", (c) => {
+  throw problems.create("ORDER_CONFLICT", {
+    detail: `Order ${id} already exists`,
+    instance: `/orders/${id}`,
+  });
+});
+
+// With extensions
+throw problems.create("RATE_LIMITED", {
+  extensions: { retryAfter: 60 },
+});
+```
+
 ## Zod Validator Integration
 
 ```ts

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -208,5 +208,5 @@ This is correct. Call `getResponse()` inside middleware to return directly. No d
 - [x] OpenAPI integration (`hono-problem-details/openapi`) — ProblemDetailsSchema, createProblemDetailsSchema, problemDetailsResponse for @hono/zod-openapi
 - [x] Standard Schema integration (`hono-problem-details/standard-schema`) — standardSchemaProblemHook for @hono/standard-validator
 - [ ] i18n — title/detail localization
-- [ ] Problem type registry — helpers for defining/managing custom problem types
+- [x] Problem type registry — createProblemTypeRegistry() for type-safe error creation
 - [ ] Express adapter — alternative to express-http-problem-details

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,3 +7,4 @@ export { statusToPhrase, statusToSlug } from "./status.js";
 export { ProblemDetailsError } from "./error.js";
 export { problemDetails } from "./factory.js";
 export { problemDetailsHandler } from "./handler.js";
+export { createProblemTypeRegistry } from "./registry.js";

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,0 +1,46 @@
+import { ProblemDetailsError } from "./error.js";
+
+interface ProblemTypeDefinition {
+	type: string;
+	status: number;
+	title: string;
+}
+
+interface CreateOptions<T extends Record<string, unknown> = Record<string, unknown>> {
+	detail?: string;
+	instance?: string;
+	extensions?: T;
+}
+
+interface ProblemTypeRegistry<K extends string> {
+	create: <T extends Record<string, unknown>>(
+		key: K,
+		options?: CreateOptions<T>,
+	) => ProblemDetailsError;
+	get: (key: K) => ProblemTypeDefinition;
+	types: () => K[];
+}
+
+/**
+ * Create a registry of pre-defined problem types.
+ * Provides type-safe error creation from registered definitions.
+ */
+export function createProblemTypeRegistry<K extends string>(
+	definitions: Record<K, ProblemTypeDefinition>,
+): ProblemTypeRegistry<K> {
+	return {
+		create: (key, options) => {
+			const def = definitions[key];
+			return new ProblemDetailsError({
+				type: def.type,
+				status: def.status,
+				title: def.title,
+				detail: options?.detail,
+				instance: options?.instance,
+				extensions: options?.extensions,
+			});
+		},
+		get: (key) => definitions[key],
+		types: () => Object.keys(definitions) as K[],
+	};
+}

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import type { ProblemDetailsError } from "../src/error.js";
+import { createProblemTypeRegistry } from "../src/registry.js";
+
+describe("createProblemTypeRegistry", () => {
+	const registry = createProblemTypeRegistry({
+		ORDER_CONFLICT: {
+			type: "https://api.example.com/problems/order-conflict",
+			status: 409,
+			title: "Order Conflict",
+		},
+		RATE_LIMITED: {
+			type: "https://api.example.com/problems/rate-limited",
+			status: 429,
+			title: "Too Many Requests",
+		},
+		NOT_FOUND: {
+			type: "https://api.example.com/problems/not-found",
+			status: 404,
+			title: "Not Found",
+		},
+	});
+
+	it("R1: create() returns ProblemDetailsError with registered type", () => {
+		const error = registry.create("ORDER_CONFLICT");
+		expect(error.problemDetails.type).toBe("https://api.example.com/problems/order-conflict");
+		expect(error.problemDetails.status).toBe(409);
+		expect(error.problemDetails.title).toBe("Order Conflict");
+	});
+
+	it("R2: create() accepts overrides for detail and instance", () => {
+		const error = registry.create("NOT_FOUND", {
+			detail: "User 123 not found",
+			instance: "/users/123",
+		});
+		expect(error.problemDetails.detail).toBe("User 123 not found");
+		expect(error.problemDetails.instance).toBe("/users/123");
+	});
+
+	it("R3: create() accepts extensions", () => {
+		const error = registry.create("RATE_LIMITED", {
+			extensions: { retryAfter: 60 },
+		});
+		expect(error.problemDetails.extensions).toEqual({ retryAfter: 60 });
+	});
+
+	it("R4: create() returns ProblemDetailsError instance", () => {
+		const error = registry.create("ORDER_CONFLICT");
+		expect(error).toBeInstanceOf(Error);
+		expect(error.name).toBe("ProblemDetailsError");
+	});
+
+	it("R5: getResponse() works on registry-created errors", async () => {
+		const error = registry.create("NOT_FOUND", { detail: "Item missing" });
+		const res = error.getResponse();
+		expect(res.status).toBe(404);
+		expect(res.headers.get("Content-Type")).toBe("application/problem+json");
+
+		const body = await res.json();
+		expect(body.type).toBe("https://api.example.com/problems/not-found");
+		expect(body.detail).toBe("Item missing");
+	});
+
+	it("R6: get() returns the registered type definition", () => {
+		const def = registry.get("ORDER_CONFLICT");
+		expect(def).toEqual({
+			type: "https://api.example.com/problems/order-conflict",
+			status: 409,
+			title: "Order Conflict",
+		});
+	});
+
+	it("R7: types() returns all registered type keys", () => {
+		const keys = registry.types();
+		expect(keys).toEqual(["ORDER_CONFLICT", "RATE_LIMITED", "NOT_FOUND"]);
+	});
+
+	it("R8: create() returns correct type", () => {
+		const error = registry.create("ORDER_CONFLICT");
+		expectTypeOf(error).toMatchTypeOf<ProblemDetailsError>();
+	});
+});


### PR DESCRIPTION
## Summary

- Add `createProblemTypeRegistry()` for pre-defining API error types
- Type-safe keys: `registry.create("ORDER_CONFLICT")` with autocomplete
- `registry.get(key)` to retrieve definitions, `registry.types()` for all keys
- 8 tests with 100% coverage
- Exported from main entry point
- Updated README with usage examples

Closes #24

## Test plan

- [x] `pnpm test` passes (101 tests)
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)