### PR TITLE
feat: add localize callback for i18n support

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -67,7 +67,7 @@
 ### 1.7 Error Handler
 
 - [x] `src/handler.ts` — problemDetailsHandler()
-- [x] Tests (13 tests): H1-H11 + defaultType + unknown status via mapError
+- [x] Tests (17 tests): H1-H15 + defaultType + unknown status via mapError
 
 ## Phase 2: Validator Integration
 
@@ -207,6 +207,6 @@ This is correct. Call `getResponse()` inside middleware to return directly. No d
 
 - [x] OpenAPI integration (`hono-problem-details/openapi`) — ProblemDetailsSchema, createProblemDetailsSchema, problemDetailsResponse for @hono/zod-openapi
 - [x] Standard Schema integration (`hono-problem-details/standard-schema`) — standardSchemaProblemHook for @hono/standard-validator
-- [ ] i18n — title/detail localization
+- [x] i18n — `localize` callback on ProblemDetailsHandlerOptions for title/detail localization
 - [x] Problem type registry — createProblemTypeRegistry() for type-safe error creation
 - [ ] Express adapter — alternative to express-http-problem-details

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,4 +42,6 @@ export interface ProblemDetailsHandlerOptions {
 	includeStack?: boolean;
 	/** Custom error to ProblemDetails mapping */
 	mapError?: (error: Error) => ProblemDetailsInput | undefined;
+	/** Localize title/detail before sending the response */
+	localize?: (pd: ProblemDetails, c: import("hono").Context) => ProblemDetails;
 }


### PR DESCRIPTION
## Summary
- Add `localize` callback to `ProblemDetailsHandlerOptions` for title/detail translation
- Callback receives `ProblemDetails` + Hono `Context` (for `Accept-Language` access)
- Applies to all error paths: HTTPException, generic Error, and mapError

## Test plan
- [x] H12: localize transforms title/detail before response
- [x] H13: localize receives Hono context for Accept-Language
- [x] H14: localize applies to generic Error responses
- [x] H15: localize applies to mapError responses
- [x] 105 tests passing, 100% coverage

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)