### PR TITLE
docs: add Used By section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,13 @@ problemDetailsHandler({
 });
 ```
 
+## Used By
+
+The following Hono middleware libraries use `hono-problem-details` as an optional dependency for RFC 9457 error responses:
+
+- [hono-idempotency](https://github.com/paveg/hono-idempotency) — Idempotency key middleware for Hono
+- [hono-webhook-verify](https://github.com/paveg/hono-webhook-verify) — Webhook signature verification middleware for Hono
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary
- Add "Used By" section to README linking ecosystem middleware libraries
- Creates mutual discoverability between hono-problem-details and integrating libraries

## Libraries linked
- [hono-idempotency](https://github.com/paveg/hono-idempotency)
- [hono-webhook-verify](https://github.com/paveg/hono-webhook-verify)

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)