### PR TITLE
test: fix F10 prototype pollution test assertions

### DIFF
--- a/tests/factory.test.ts
+++ b/tests/factory.test.ts
@@ -99,6 +99,11 @@ describe("problemDetails factory", () => {
 		const response = error.getResponse();
 		const body = await response.json();
 		expect(body.status).toBe(400);
+		// constructor extension key appears in serialized body
+		expect(body.constructor).toBe("bad");
+		// __proto__ in object literals sets prototype, not own property — not serialized
+		expect(Object.hasOwn(body, "__proto__")).toBe(false);
+		// Object.prototype is not polluted
 		expect(({} as Record<string, unknown>).polluted).toBeUndefined();
 	});
 });


### PR DESCRIPTION
## Summary
- Add meaningful assertions to F10 that verify actual behavior
- `body.constructor` should be `"bad"` (extension key in serialized body)
- `__proto__` should be absent (not an own property in object literals)
- Previous `({}).polluted` assertion retained but now supplemented

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)