### PR TITLE
refactor: unify ProblemDetailsError path through toResponse

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -44,8 +44,7 @@ function toResponse(
 export function problemDetailsHandler(options: ProblemDetailsHandlerOptions = {}): ErrorHandler {
 	return (error, c) => {
 		if (error instanceof ProblemDetailsError) {
-			c.set("problemDetails", error.problemDetails);
-			return error.getResponse();
+			return toResponse(error.problemDetails, c, options);
 		}
 
 		if (options.mapError) {

--- a/tests/handler.test.ts
+++ b/tests/handler.test.ts
@@ -264,7 +264,7 @@ describe("problemDetailsHandler", () => {
 		expect((captured as { status: number }).status).toBe(409);
 	});
 
-	it("H17: localize is NOT applied to ProblemDetailsError (uses pre-built response)", async () => {
+	it("H17: localize applies to ProblemDetailsError", async () => {
 		const app = createApp({
 			localize: (pd) => ({ ...pd, title: "Localized" }),
 		});
@@ -273,7 +273,7 @@ describe("problemDetailsHandler", () => {
 		});
 		const res = await app.request("/");
 		const body = await res.json();
-		expect(body.title).toBe("Not Found");
+		expect(body.title).toBe("Localized");
 	});
 
 	it("H18: falls back to about:blank when typePrefix is set but status is unknown", async () => {


### PR DESCRIPTION
## Summary
- Route `ProblemDetailsError` through `toResponse()` instead of calling `getResponse()` directly
- This ensures `localize`, context-setting (`c.set("problemDetails", ...)`), and extensions spread are handled uniformly for all error types
- Updated H17 test: `localize` now correctly applies to `ProblemDetailsError`

Closes #38

## Test plan
- [x] All 117 tests pass
- [x] 100% coverage maintained
- [x] `localize` callback now applies to ProblemDetailsError (H17 verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)