### PR TITLE
perf: pre-compute STATUS_SLUGS map for O(1) lookup

### DIFF
--- a/benchmarks/status.bench.ts
+++ b/benchmarks/status.bench.ts
@@ -1,0 +1,26 @@
+import { bench, describe } from "vitest";
+import { statusToPhrase, statusToSlug } from "../src/status.js";
+
+describe("statusToSlug", () => {
+	bench("lookup known status 404", () => {
+		statusToSlug(404);
+	});
+
+	bench("lookup known status 500", () => {
+		statusToSlug(500);
+	});
+
+	bench("lookup unknown status 999", () => {
+		statusToSlug(999);
+	});
+});
+
+describe("statusToPhrase", () => {
+	bench("lookup known status 404", () => {
+		statusToPhrase(404);
+	});
+
+	bench("lookup unknown status 999", () => {
+		statusToPhrase(999);
+	});
+});

--- a/src/status.ts
+++ b/src/status.ts
@@ -21,12 +21,17 @@ const STATUS_PHRASES: Record<number, string> = {
 	504: "Gateway Timeout",
 };
 
+const STATUS_SLUGS: Record<number, string> = Object.fromEntries(
+	Object.entries(STATUS_PHRASES).map(([code, phrase]) => [
+		Number(code),
+		phrase.toLowerCase().replace(/ /g, "-"),
+	]),
+);
+
 export function statusToPhrase(status: number): string | undefined {
 	return STATUS_PHRASES[status];
 }
 
 export function statusToSlug(status: number): string | undefined {
-	const phrase = STATUS_PHRASES[status];
-	if (!phrase) return undefined;
-	return phrase.toLowerCase().replace(/ /g, "-");
+	return STATUS_SLUGS[status];
 }


### PR DESCRIPTION
## Summary
- Pre-compute `STATUS_SLUGS` record at module init time instead of calling `.toLowerCase().replace()` on every `statusToSlug()` invocation
- Added benchmark file (`benchmarks/status.bench.ts`)

Closes #40

## Benchmark Results

### Before (string manipulation per call)
| Function | ops/s |
|----------|-------|
| `statusToSlug(404)` | 10,388,694 |
| `statusToSlug(500)` | 8,298,150 |
| `statusToSlug(999)` | 29,449,831 |

### After (pre-computed map lookup)
| Function | ops/s | Speedup |
|----------|-------|---------|
| `statusToSlug(404)` | 40,384,514 | **3.9x** |
| `statusToSlug(500)` | 40,762,849 | **4.9x** |
| `statusToSlug(999)` | 41,279,048 | 1.4x |

All known status codes now match `statusToPhrase` performance (~40M ops/s).

## Test plan
- [x] All 117 tests pass
- [x] 100% coverage maintained
- [x] Lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)