### PR TITLE
feat: add JSR publish support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - run: pnpm install --frozen-lockfile
       - uses: changesets/action@v1
+        id: changesets
         with:
           publish: pnpm release
           version: pnpm version-packages
@@ -32,3 +33,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish to JSR
+        if: steps.changesets.outputs.published == 'true'
+        run: npx jsr publish

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
 	"name": "@paveg/hono-problem-details",
-	"version": "0.0.0",
+	"version": "0.1.1",
 	"exports": {
 		".": "./src/index.ts",
 		"./zod": "./src/integrations/zod.ts",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 		"format": "biome format --write .",
 		"typecheck": "tsc --noEmit",
 		"release": "pnpm build && changeset publish",
-		"version-packages": "changeset version && pnpm lint:fix"
+		"version-packages": "changeset version && node -e \"const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));const j=JSON.parse(fs.readFileSync('jsr.json','utf8'));j.version=p.version;fs.writeFileSync('jsr.json',JSON.stringify(j,null,'\\t')+'\\n')\" && pnpm lint:fix"
 	},
 	"keywords": [
 		"hono",

--- a/src/integrations/openapi.ts
+++ b/src/integrations/openapi.ts
@@ -5,7 +5,13 @@ import { statusToPhrase } from "../status.js";
  * Base RFC 9457 Problem Details Zod schema for OpenAPI documentation.
  * Use in createRoute() response definitions with @hono/zod-openapi.
  */
-export const ProblemDetailsSchema = z
+export const ProblemDetailsSchema: z.ZodObject<{
+	type: z.ZodString;
+	status: z.ZodNumber;
+	title: z.ZodString;
+	detail: z.ZodOptional<z.ZodString>;
+	instance: z.ZodOptional<z.ZodString>;
+}> = z
 	.object({
 		type: z.string().openapi({ description: "Problem type URI", example: "about:blank" }),
 		status: z.number().int().openapi({ description: "HTTP status code", example: 400 }),
@@ -21,7 +27,9 @@ export const ProblemDetailsSchema = z
  * Create a Problem Details schema with typed extension members.
  * Extensions are merged at top level per RFC 9457.
  */
-export function createProblemDetailsSchema<T extends z.ZodRawShape>(extensions: z.ZodObject<T>) {
+export function createProblemDetailsSchema<T extends z.ZodRawShape>(
+	extensions: z.ZodObject<T>,
+): z.AnyZodObject {
 	return ProblemDetailsSchema.merge(extensions).openapi({ title: "ProblemDetails" });
 }
 
@@ -33,7 +41,10 @@ export function problemDetailsResponse(
 	status: number,
 	description?: string,
 	schema: z.ZodTypeAny = ProblemDetailsSchema,
-) {
+): {
+	content: { "application/problem+json": { schema: z.ZodTypeAny } };
+	description: string;
+} {
 	return {
 		content: {
 			"application/problem+json": { schema },

--- a/src/integrations/standard-schema.ts
+++ b/src/integrations/standard-schema.ts
@@ -24,13 +24,15 @@ function formatIssues(issues: readonly StandardSchemaV1.Issue[]): ValidationErro
 	}));
 }
 
-export function standardSchemaProblemHook(options?: StandardSchemaProblemHookOptions) {
-	return (
-		result:
-			| { success: true; data: unknown }
-			| { success: false; error: readonly StandardSchemaV1.Issue[] },
-		c: Context,
-	) => {
+export function standardSchemaProblemHook(
+	options?: StandardSchemaProblemHookOptions,
+): (
+	result:
+		| { success: true; data: unknown }
+		| { success: false; error: readonly StandardSchemaV1.Issue[] },
+	c: Context,
+) => Response | undefined {
+	return (result, c) => {
 		if (result.success) return;
 
 		const body = {

--- a/src/integrations/valibot.ts
+++ b/src/integrations/valibot.ts
@@ -20,8 +20,10 @@ function formatIssues(issues: BaseIssue<unknown>[]): ValidationError[] {
 	}));
 }
 
-export function valibotProblemHook(options?: ValibotProblemHookOptions) {
-	return (result: SafeParseResult<never> & { target: string }, c: Context) => {
+export function valibotProblemHook(
+	options?: ValibotProblemHookOptions,
+): (result: SafeParseResult<never> & { target: string }, c: Context) => Response | undefined {
+	return (result, c) => {
 		if (result.success) return;
 
 		const body = {

--- a/src/integrations/zod.ts
+++ b/src/integrations/zod.ts
@@ -20,11 +20,13 @@ function formatErrors(zodError: ZodError): ValidationError[] {
 	}));
 }
 
-export function zodProblemHook(options?: ZodProblemHookOptions) {
-	return (
-		result: { success: true; data: unknown } | { success: false; error: ZodError },
-		c: Context,
-	) => {
+export function zodProblemHook(
+	options?: ZodProblemHookOptions,
+): (
+	result: { success: true; data: unknown } | { success: false; error: ZodError },
+	c: Context,
+) => Response | undefined {
+	return (result, c) => {
 		if (result.success) return;
 
 		const body = {


### PR DESCRIPTION
## Summary
- Add `jsr.json` with subpath exports pointing to TypeScript source files
- Add explicit return types to all public API functions to pass JSR's slow types check
- Add JSR publish step to release workflow (triggers after npm publish via changesets)
- Sync `jsr.json` version from `package.json` in `version-packages` script

Closes #33

## JSR Dry-Run Output
```
Simulating publish of @paveg/hono-problem-details@0.1.1 with files:
  LICENSE (1.06KB)
  README.md (7.49KB)
  jsr.json (381B)
  src/error.ts (1.02KB)
  src/factory.ts (272B)
  src/handler.ts (2.02KB)
  src/index.ts (375B)
  src/integrations/openapi.ts (1.76KB)
  src/integrations/standard-schema.ts (1.31KB)
  src/integrations/valibot.ts (1.04KB)
  src/integrations/zod.ts (1.02KB)
  src/registry.ts (1.12KB)
  src/status.ts (939B)
  src/types.ts (1.49KB)
Success Dry run complete
```

## Test plan
- [x] All 117 tests pass
- [x] `npx jsr publish --dry-run` passes (no slow type errors)
- [x] Lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)