### PR TITLE
fix: security hardening (extensions sanitization, charset)

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -1,3 +1,4 @@
+import { PROBLEM_JSON_CONTENT_TYPE, sanitizeExtensions } from "./handler.js";
 import { statusToPhrase } from "./status.js";
 import type { ProblemDetails, ProblemDetailsInput } from "./types.js";
 
@@ -26,10 +27,10 @@ export class ProblemDetailsError extends Error {
 
 	getResponse(): Response {
 		const { extensions, ...standard } = this.problemDetails;
-		const body = { ...extensions, ...standard };
+		const body = { ...sanitizeExtensions(extensions), ...standard };
 		return new Response(JSON.stringify(body), {
 			status: this.problemDetails.status,
-			headers: { "Content-Type": "application/problem+json" },
+			headers: { "Content-Type": PROBLEM_JSON_CONTENT_TYPE },
 		});
 	}
 }

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -54,7 +54,7 @@ describe("createProblemTypeRegistry", () => {
 		const error = registry.create("NOT_FOUND", { detail: "Item missing" });
 		const res = error.getResponse();
 		expect(res.status).toBe(404);
-		expect(res.headers.get("Content-Type")).toBe("application/problem+json");
+		expect(res.headers.get("Content-Type")).toBe("application/problem+json; charset=utf-8");
 
 		const body = await res.json();
 		expect(body.type).toBe("https://api.example.com/problems/not-found");


### PR DESCRIPTION
## Summary
- Strip `__proto__` / `constructor` / `prototype` keys from extensions before JSON serialization to prevent prototype pollution in downstream consumers
- Add `charset=utf-8` to `Content-Type` header per RFC 9457 §3
- Applied to both `toResponse()` (handler path) and `ProblemDetailsError.getResponse()`

## Changes
- `src/handler.ts`: Add `PROBLEM_JSON_CONTENT_TYPE` constant, `sanitizeExtensions()` helper
- `src/error.ts`: Use shared constant and sanitizer
- Tests updated: F10 (extensions sanitization), F11 (charset), H10 (charset), H23 (handler extensions sanitization), R5 (registry charset)

Closes #43

## Test plan
- [x] F10: Dangerous extension keys stripped from response body
- [x] F11: Content-Type includes `charset=utf-8`
- [x] H10: Handler Content-Type includes `charset=utf-8`  
- [x] H23: Handler strips dangerous extension keys
- [x] All 119 tests pass
- [x] Lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)