### PR TITLE
fix: validate HTTP status code range in response

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -54,8 +54,11 @@ function toResponse(
 
 	c.set("problemDetails", pd);
 
+	// HTTP status must be 100-599; use body status as-is (RFC 9457 advisory)
+	const httpStatus = pd.status >= 100 && pd.status <= 599 ? pd.status : 500;
+
 	return new Response(JSON.stringify(body), {
-		status: pd.status,
+		status: httpStatus,
 		headers: { "Content-Type": PROBLEM_JSON_CONTENT_TYPE },
 	});
 }

--- a/tests/handler.test.ts
+++ b/tests/handler.test.ts
@@ -355,4 +355,41 @@ describe("problemDetailsHandler", () => {
 		const body = await res.json();
 		expect(res.status).toBe(body.status);
 	});
+
+	it("H24: clamps invalid status code to 500 in HTTP response", async () => {
+		const app = createApp({
+			mapError: () => ({ status: 9999, title: "Invalid" }),
+		});
+		app.get("/", () => {
+			throw new Error("test");
+		});
+		const res = await app.request("/");
+		expect(res.status).toBe(500);
+		const body = await res.json();
+		expect(body.status).toBe(9999);
+	});
+
+	it("H25: clamps negative status code to 500", async () => {
+		const app = createApp({
+			mapError: () => ({ status: -1, title: "Negative" }),
+		});
+		app.get("/", () => {
+			throw new Error("test");
+		});
+		const res = await app.request("/");
+		expect(res.status).toBe(500);
+	});
+
+	it("H26: accepts valid error status codes (400-599)", async () => {
+		for (const status of [400, 404, 500, 599]) {
+			const app = createApp({
+				mapError: () => ({ status, title: "Test" }),
+			});
+			app.get("/", () => {
+				throw new Error("test");
+			});
+			const res = await app.request("/");
+			expect(res.status).toBe(status);
+		}
+	});
 });


### PR DESCRIPTION
## Summary
- Validate that status code is in valid HTTP range (100-599) before creating Response
- Invalid status codes (e.g., 9999, -1) fall back to 500 for the HTTP response
- Body status preserved as-is per RFC 9457 (status member is advisory)

## Changes
- `src/handler.ts`: Add status validation in `toResponse()`
- `tests/handler.test.ts`: H24 (invalid status → 500), H25 (negative → 500), H26 (valid range preserved)

Closes #45

## Test plan
- [x] H24: status 9999 → HTTP 500, body.status 9999
- [x] H25: status -1 → HTTP 500
- [x] H26: status 400/404/500/599 all preserved
- [x] All 122 tests pass
- [x] Lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)