### PR TITLE
fix: add typesVersions for moduleResolution node compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,14 @@
 			}
 		}
 	},
+	"typesVersions": {
+		"*": {
+			"zod": ["./dist/integrations/zod.d.ts"],
+			"valibot": ["./dist/integrations/valibot.d.ts"],
+			"openapi": ["./dist/integrations/openapi.d.ts"],
+			"standard-schema": ["./dist/integrations/standard-schema.d.ts"]
+		}
+	},
 	"files": ["dist"],
 	"sideEffects": false,
 	"scripts": {


### PR DESCRIPTION
## Summary
- Add `typesVersions` field to `package.json` so subpath imports (`hono-problem-details/standard-schema`, `/zod`, `/valibot`, `/openapi`) resolve correctly under `moduleResolution: "node"`
- The `exports` field only works with `"node16"`, `"nodenext"`, or `"bundler"` — `typesVersions` acts as a fallback for older settings

Closes #67

## Test plan
- [x] Verified `pnpm build`, `pnpm typecheck`, `pnpm test` all pass
- [x] Verified types resolve with `moduleResolution: "node"` in a separate test project

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package configuration to improve TypeScript type resolution for integration modules (zod, valibot, openapi, standard-schema).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->