### PR TITLE
fix: make valibotProblemHook() type-compatible with @hono/valibot-validator Hook

### DIFF
--- a/src/integrations/valibot.ts
+++ b/src/integrations/valibot.ts
@@ -1,5 +1,5 @@
 import type { Context } from "hono";
-import type { BaseIssue, SafeParseResult } from "valibot";
+import type { BaseIssue, GenericSchema, GenericSchemaAsync, SafeParseResult } from "valibot";
 import {
 	type ValidationError,
 	type ValidationHookOptions,
@@ -16,9 +16,9 @@ function formatIssues(issues: BaseIssue<unknown>[]): ValidationError[] {
 	}));
 }
 
-export function valibotProblemHook(
+export function valibotProblemHook<T extends GenericSchema | GenericSchemaAsync = GenericSchema>(
 	options?: ValidationHookOptions,
-): (result: SafeParseResult<never> & { target: string }, c: Context) => Response | undefined {
+): (result: SafeParseResult<T> & { target: string }, c: Context) => Response | undefined {
 	return (result, _c) => {
 		if (result.success) return;
 		return buildValidationResponse(formatIssues(result.issues), options);

--- a/tests/integrations/valibot.test.ts
+++ b/tests/integrations/valibot.test.ts
@@ -1,5 +1,7 @@
+import type { Hook } from "@hono/valibot-validator";
 import { vValidator } from "@hono/valibot-validator";
 import { Hono } from "hono";
+import type { Env } from "hono";
 import * as v from "valibot";
 import { describe, expect, it } from "vitest";
 import { valibotProblemHook } from "../../src/integrations/valibot.js";
@@ -22,6 +24,14 @@ function createApp(hookOptions?: Parameters<typeof valibotProblemHook>[0]) {
 }
 
 describe("valibotProblemHook", () => {
+	it("V8: return type is assignable to @hono/valibot-validator Hook type", () => {
+		const schema = v.object({ name: v.string() });
+		type Schema = typeof schema;
+		// This assignment must compile without `as never` cast
+		const hook: Hook<Schema, Env, string> = valibotProblemHook();
+		expect(typeof hook).toBe("function");
+	});
+
 	it("V1: passes through on validation success", async () => {
 		const app = createApp();
 		const res = await app.request("/users", {


### PR DESCRIPTION
## Summary

- Changed `valibotProblemHook()` return type from `SafeParseResult<never>` to `SafeParseResult<T>`, making it compatible with `@hono/valibot-validator`'s `Hook` type
- Added generic type parameter `T extends GenericSchema | GenericSchemaAsync = GenericSchema`
- Users no longer need `as never` cast when passing `valibotProblemHook()` to `vValidator()`

## Test plan

- [x] V8: Type compatibility test asserting assignability to `Hook<Schema, Env, string>`
- [x] All 178 existing tests pass
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced generic type support for Valibot validation hook, enabling improved type inference and IDE autocomplete when handling validation results.

* **Tests**
  * Added type compatibility tests for Valibot validation hook integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->