### PR TITLE
fix: make valibotProblemHook() type-compatible with @hono/valibot-validator Hook

### DIFF
--- a/.changeset/fix-valibot-hook-type.md
+++ b/.changeset/fix-valibot-hook-type.md
@@ -1,0 +1,5 @@
+---
+"hono-problem-details": patch
+---
+
+Make `valibotProblemHook()` generic to match `@hono/valibot-validator` Hook type, removing the need for `as never` cast


### PR DESCRIPTION
## Summary

- Made `valibotProblemHook()` generic with `T extends GenericSchema | GenericSchemaAsync = GenericSchema`, changing return type from `SafeParseResult<never>` to `SafeParseResult<T>`
- Users no longer need `as never` cast when passing `valibotProblemHook()` to `vValidator()`
- Added type compatibility test (V8) asserting assignability to `Hook<Schema, Env, string>`

## Test plan

- [x] V8: Type compatibility test — `Hook<Schema, Env, string> = valibotProblemHook()` compiles without cast
- [x] All 178 existing tests pass
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)