### PR TITLE
ci: add Dependabot config for npm and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "paveg"
+    labels:
+      - "dependencies"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+      production-dependencies:
+        dependency-type: "production"
+    ignore:
+      # Never auto-bump peer dep majors — those are coordinated with users
+      - dependency-name: "hono"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 3
+    reviewers:
+      - "paveg"
+    labels:
+      - "dependencies"
+      - "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

**Security audit finding M-2**: npm パッケージとして公開されているこのリポジトリには `.github/dependabot.yml` が存在せず、peer deps（`zod`, `valibot`, `@hono/*`）や GitHub Actions の脆弱性アラートが自動化されていませんでした。Dependabot を追加することで、依存関係の CVE 通知と SHA pinned Actions のメンテナンスを自動化します。

### 変更点

- `.github/dependabot.yml` を新規追加
  - **npm**: 毎週月曜 9:00 JST、`dev-dependencies` / `production-dependencies` でグループ化、5 PR 上限
  - **github-actions**: 毎週月曜 9:00 JST、全 actions を 1 グループ化、3 PR 上限
  - `hono` の major 更新のみ無視（peer dep 協調リリースのため）

### 関連

- companion PR: Actions SHA pinning (`security/workflow-hardening`) — Dependabot がその SHA を自動更新する前提

## Checklist

- [x] Tests added/updated — N/A (config file only)
- [x] \`pnpm test\` passes — unchanged
- [x] \`pnpm typecheck\` passes — unchanged
- [x] \`pnpm lint\` passes — unchanged
- [ ] Changeset added — N/A (CI-only change, no library behavior)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated weekly dependency update configuration for npm packages and GitHub Actions, with customized scheduling and reviewer assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->