### PR TITLE
fix(handler): guard localize callback against throws

### DIFF
--- a/.changeset/fix-handler-localize-guard.md
+++ b/.changeset/fix-handler-localize-guard.md
@@ -1,0 +1,8 @@
+---
+"hono-problem-details": patch
+---
+
+Guard `problemDetailsHandler`'s `localize` callback against throws. A localize
+function that threw would previously bubble out of the error handler and
+re-enter Hono's `onError`, risking recursion. The handler now catches throws
+and falls back to the un-localized problem details.

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -21,7 +21,12 @@ function toResponse(
 	let pd = normalizeProblemDetails(input);
 
 	if (options.localize) {
-		pd = { ...pd, ...options.localize(pd, c) };
+		try {
+			pd = { ...pd, ...options.localize(pd, c) };
+		} catch {
+			// Fall through with the un-localized pd. A throwing localize must not
+			// cause the error handler itself to throw — that would re-enter onError.
+		}
 	}
 
 	c.set("problemDetails", pd);

--- a/tests/handler.test.ts
+++ b/tests/handler.test.ts
@@ -514,4 +514,62 @@ describe("problemDetailsHandler", () => {
 			expect(res.status).toBe(status);
 		}
 	});
+
+	it("H35: localize throwing Error falls back to un-localized response", async () => {
+		const app = createApp({
+			localize: () => {
+				throw new Error("boom");
+			},
+		});
+		app.get("/", () => {
+			throw problemDetails({
+				status: 400,
+				title: "Bad Request",
+				detail: "original detail",
+			});
+		});
+		const res = await app.request("/");
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.title).toBe("Bad Request");
+		expect(body.detail).toBe("original detail");
+		expect(JSON.stringify(body)).not.toContain("boom");
+	});
+
+	it("H36: localize throwing non-Error value falls back to un-localized response", async () => {
+		const app = createApp({
+			localize: () => {
+				throw "string thrown";
+			},
+		});
+		app.get("/", () => {
+			throw problemDetails({
+				status: 400,
+				title: "Bad Request",
+				detail: "original detail",
+			});
+		});
+		const res = await app.request("/");
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.title).toBe("Bad Request");
+		expect(body.detail).toBe("original detail");
+	});
+
+	it("H37: localize returning normally still applies (regression guard)", async () => {
+		const app = createApp({
+			localize: (pd) => ({ ...pd, title: "Localized" }),
+		});
+		app.get("/", () => {
+			throw problemDetails({
+				status: 400,
+				title: "Bad Request",
+				detail: "original detail",
+			});
+		});
+		const res = await app.request("/");
+		expect(res.status).toBe(400);
+		const body = await res.json();
+		expect(body.title).toBe("Localized");
+	});
 });


### PR DESCRIPTION
## Summary

**Security audit finding L-1**: \`problemDetailsHandler\` の \`options.localize()\` 呼び出しが try/catch されておらず、localize 内で throw すると Hono の \`onError\` に例外が再突入する可能性がありました（recursion / unhandled error リスク）。

### 修正

\`src/handler.ts\` の \`toResponse\` 内で \`localize\` 呼び出しを try/catch で包み、throw 時は **un-localized な problem details にフォールバック**します。ログや rethrow は意図的に行いません（目的は封じ込め）。

\`\`\`ts
if (options.localize) {
    try {
        pd = { ...pd, ...options.localize(pd, c) };
    } catch {
        // Fall through with the un-localized pd.
    }
}
\`\`\`

### テスト (TDD)

- **H35**: \`localize\` が \`Error\` を throw → response は un-localized な pd を返す（\"boom\" テキストが含まれないこと）
- **H36**: \`localize\` が string を throw → 同じく un-localized 経路にフォールバック
- **H37**: \`localize\` が正常に値を返す → 従来通り localize 結果が適用される（回帰ガード）

Red phase で H35/H36 が失敗することを確認後、fix を適用して Green phase で 3 件全て PASS + 既存の 181 テストも全 PASS を確認。

## Checklist

- [x] Tests added/updated (H35, H36, H37)
- [x] \`pnpm test\` passes (181 passed across 10 files)
- [x] Coverage 100% on all metrics
- [x] \`pnpm typecheck\` passes
- [x] \`pnpm lint\` passes (on changed files)
- [x] Changeset added (patch)