### PR TITLE
fix(utils): require integer for clampHttpStatus

### DIFF
--- a/.changeset/fix-utils-integer-status.md
+++ b/.changeset/fix-utils-integer-status.md
@@ -1,0 +1,8 @@
+---
+"hono-problem-details": patch
+---
+
+`clampHttpStatus` now requires an integer via `Number.isInteger`. Previously
+strings, floats, and BigInts could slip through the 200–599 range check via
+JavaScript type coercion, producing undefined behavior in stricter fetch
+runtimes. Non-integer or out-of-range values now fall back to 500.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,9 +20,9 @@ export function sanitizeExtensions(
 	return filtered ?? extensions;
 }
 
-/** Clamp HTTP status to 200-599 range; returns 500 for out-of-range values */
+/** Clamp HTTP status to 200-599 integer range; returns 500 for out-of-range or non-integer values */
 export function clampHttpStatus(status: number): number {
-	return status >= 200 && status <= 599 ? status : 500;
+	return Number.isInteger(status) && status >= 200 && status <= 599 ? status : 500;
 }
 
 const FALLBACK_BODY = JSON.stringify({

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -69,6 +69,26 @@ describe("clampHttpStatus", () => {
 	])("U8: clamps %d to 500", (input, expected) => {
 		expect(clampHttpStatus(input)).toBe(expected);
 	});
+
+	it("U21: returns 500 for non-integer float", () => {
+		expect(clampHttpStatus(200.5)).toBe(500);
+	});
+
+	it("U22: returns 500 for numeric string", () => {
+		expect(clampHttpStatus("200" as unknown as number)).toBe(500);
+	});
+
+	it("U23: returns 500 for BigInt", () => {
+		expect(clampHttpStatus(200n as unknown as number)).toBe(500);
+	});
+
+	it("U24: returns 500 for NaN", () => {
+		expect(clampHttpStatus(Number.NaN)).toBe(500);
+	});
+
+	it("U25: returns 500 for Infinity", () => {
+		expect(clampHttpStatus(Number.POSITIVE_INFINITY)).toBe(500);
+	});
 });
 
 describe("normalizeProblemDetails", () => {


### PR DESCRIPTION
## Summary

**Security audit finding L-2**: \`clampHttpStatus(status: number)\` が JS の型強制により非整数値を素通しさせていました。

| 入力 | 従来 | 修正後 |
|---|---|---|
| \`200.5\` (float) | \`200.5\` を返す | \`500\` |
| \`\"200\"\` (string、型キャスト経由) | \`\"200\"\` を返す | \`500\` |
| \`200n\` (BigInt) | \`200n\` を返す | \`500\` |
| \`NaN\` | \`500\` | \`500\` (不変) |
| \`Infinity\` | \`500\` | \`500\` (不変) |
| \`200\` (integer, valid) | \`200\` | \`200\` (不変) |

### 何が問題か

Node の \`Response\` コンストラクタは lenient で非整数を受け付けてしまうランタイムもありますが、undici などの厳格な fetch 実装では throw します。\`mapError\` で外部システムから渡ってきた status をそのまま渡すような利用パターンで、予期しない crash や挙動分岐を引き起こす可能性がありました。

### 修正

\`Number.isInteger()\` を整数ゲートとして追加：

\`\`\`ts
export function clampHttpStatus(status: number): number {
    return Number.isInteger(status) && status >= 200 && status <= 599 ? status : 500;
}
\`\`\`

### テスト (TDD)

- **U21** (float 200.5), **U22** (\"200\" 文字列), **U23** (200n BigInt) — Red phase で失敗を確認 → fix で通過
- **U24** (NaN), **U25** (Infinity) — 回帰ガード
- 既存の integer happy path / boundary test (U7, U8 相当) は変更なしで通過

183/183 全 PASS、coverage 100%、downstream 回帰なし（\`handler.ts\` と \`status.ts\` は常に integer literal を渡しているため）。

## Checklist

- [x] Tests added/updated (U21–U25)
- [x] \`pnpm test\` passes (183 passed)
- [x] Coverage 100%
- [x] \`pnpm typecheck\` passes
- [x] \`pnpm lint\` passes (on changed files)
- [x] Changeset added (patch)