### PR TITLE
fix(validators): strip C0 control chars from validation error output

### DIFF
--- a/.changeset/fix-validators-strip-control-chars.md
+++ b/.changeset/fix-validators-strip-control-chars.md
@@ -1,0 +1,10 @@
+---
+"hono-problem-details": patch
+---
+
+Validator hooks (`zod`, `valibot`, `standard-schema`) now strip C0 control
+characters (`\x00`–`\x1f`) and DEL (`\x7f`) from `field` and `message` in the
+`errors[]` array before serialization. This prevents log-line spoofing via
+BEL / backspace / similar controls embedded in user-supplied field names.
+Bidi/format controls (`U+202E` etc.) are intentionally left intact to avoid
+breaking legitimate i18n content.

--- a/src/integrations/validation.ts
+++ b/src/integrations/validation.ts
@@ -11,6 +11,27 @@ export interface ValidationHookOptions {
 	detail?: string;
 }
 
+/**
+ * Strip C0 control characters (\x00-\x1f) and DEL (\x7f) from untrusted text.
+ * Bidi/format control chars (U+2028, U+202E, etc.) are intentionally left intact
+ * to avoid breaking legitimate i18n content; log consumers should apply their
+ * own bidi-safe rendering.
+ */
+// biome-ignore lint/suspicious/noControlCharactersInRegex: intentional stripping of C0 controls
+const CONTROL_CHAR_RE = /[\x00-\x1f\x7f]/g;
+
+function stripControlChars(input: string): string {
+	return input.replace(CONTROL_CHAR_RE, "");
+}
+
+function sanitizeError(error: ValidationError): ValidationError {
+	return {
+		field: stripControlChars(error.field),
+		message: stripControlChars(error.message),
+		...(error.code !== undefined ? { code: stripControlChars(error.code) } : {}),
+	};
+}
+
 /** Build a RFC 9457 validation error response from formatted errors */
 export function buildValidationResponse(
 	errors: ValidationError[],
@@ -21,7 +42,7 @@ export function buildValidationResponse(
 		status: 422,
 		title: options?.title ?? "Validation Error",
 		detail: options?.detail ?? "Request validation failed",
-		errors,
+		errors: errors.map(sanitizeError),
 	};
 
 	return new Response(JSON.stringify(body), {

--- a/tests/integrations/standard-schema.test.ts
+++ b/tests/integrations/standard-schema.test.ts
@@ -155,6 +155,29 @@ describe("standardSchemaProblemHook", () => {
 		expect(body.errors[0].field).toContain("items");
 	});
 
+	it("S9: strips C0 control characters from field and message", async () => {
+		const app = new Hono();
+		const fieldName = "name\x01ctrl";
+		const schema = v.object({
+			[fieldName]: v.pipe(v.string("required\x07bell")),
+		});
+		app.post("/ctrl", sValidator("json", schema, standardSchemaProblemHook()), (c) => c.text("ok"));
+		const res = await app.request("/ctrl", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({}),
+		});
+		expect(res.status).toBe(422);
+		const body = (await res.json()) as { errors: { field: string; message: string }[] };
+		// biome-ignore lint/suspicious/noControlCharactersInRegex: assertion target
+		const ctrlRe = /[\x00-\x1f\x7f]/;
+		for (const err of body.errors) {
+			expect(err.field).not.toMatch(ctrlRe);
+			expect(err.message).not.toMatch(ctrlRe);
+		}
+		expect(body.errors.some((e) => e.field.includes("namectrl"))).toBe(true);
+	});
+
 	it("S7: handles errors without path", async () => {
 		const app = new Hono();
 		const schema = v.pipe(

--- a/tests/integrations/valibot.test.ts
+++ b/tests/integrations/valibot.test.ts
@@ -127,6 +127,29 @@ describe("valibotProblemHook", () => {
 		expect(body.errors[0].field).toBe("");
 	});
 
+	it("V9: strips C0 control characters from field and message", async () => {
+		const app = new Hono();
+		const fieldName = "name\x01ctrl";
+		const schema = v.object({
+			[fieldName]: v.pipe(v.string("required\x07bell")),
+		});
+		app.post("/ctrl", vValidator("json", schema, valibotProblemHook()), (c) => c.text("ok"));
+		const res = await app.request("/ctrl", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({}),
+		});
+		expect(res.status).toBe(422);
+		const body = (await res.json()) as { errors: { field: string; message: string }[] };
+		// biome-ignore lint/suspicious/noControlCharactersInRegex: assertion target
+		const ctrlRe = /[\x00-\x1f\x7f]/;
+		for (const err of body.errors) {
+			expect(err.field).not.toMatch(ctrlRe);
+			expect(err.message).not.toMatch(ctrlRe);
+		}
+		expect(body.errors.some((e) => e.field.includes("namectrl"))).toBe(true);
+	});
+
 	it("V7: allows custom title and detail via options", async () => {
 		const app = createApp({
 			title: "Custom Validation Error",

--- a/tests/integrations/zod.test.ts
+++ b/tests/integrations/zod.test.ts
@@ -114,6 +114,29 @@ describe("zodProblemHook", () => {
 		expect(body.errors[0].field).toBe("");
 	});
 
+	it("Z9: strips C0 control characters from field and message", async () => {
+		const app = new Hono();
+		const fieldName = "name\x01ctrl";
+		const schema = z.object({
+			[fieldName]: z.string({ message: "required\x07bell" }),
+		});
+		app.post("/ctrl", zValidator("json", schema, zodProblemHook()), (c) => c.text("ok"));
+		const res = await app.request("/ctrl", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({}),
+		});
+		expect(res.status).toBe(422);
+		const body = (await res.json()) as { errors: { field: string; message: string }[] };
+		// biome-ignore lint/suspicious/noControlCharactersInRegex: assertion target
+		const ctrlRe = /[\x00-\x1f\x7f]/;
+		for (const err of body.errors) {
+			expect(err.field).not.toMatch(ctrlRe);
+			expect(err.message).not.toMatch(ctrlRe);
+		}
+		expect(body.errors.some((e) => e.field.includes("namectrl"))).toBe(true);
+	});
+
 	it("Z7: allows custom title and detail via options", async () => {
 		const app = createApp({
 			title: "Custom Validation Error",


### PR DESCRIPTION
## Summary

**Security audit finding L-3**: バリデーター統合（zod / valibot / standard-schema）が、ユーザー入力由来のフィールド名・エラーメッセージに含まれる C0 制御文字（\`\\x00–\\x1f\` + \`\\x7f\` DEL）をそのまま JSON レスポンスに埋め込んでいました。

### 何が問題か

\`application/problem+json\` のためブラウザでの XSS にはなりません。しかし：

1. **ログ行スプーフィング**: 端末・ログ集約ツール・\`jq\` などで BEL (\\x07) や BS (\\x08)、DEL などが解釈され視覚的混乱を招く
2. **Defense in depth**: ユーザー入力由来の文字列を非印字文字をストリップせずにログに流すのは一般的な hardening 違反

### 修正

**単一の choke point** である \`src/integrations/validation.ts\` の \`buildValidationResponse\` 内で \`errors[]\` をサニタイズすることで、3 つのバリデーター統合全てがこの修正の恩恵を受けます。

\`\`\`ts
// biome-ignore lint/suspicious/noControlCharactersInRegex: intentional stripping of C0 controls
const CONTROL_CHAR_RE = /[\\x00-\\x1f\\x7f]/g;
function stripControlChars(input: string): string {
    return input.replace(CONTROL_CHAR_RE, \"\");
}
\`\`\`

### 非破壊性

- **\`field\` のパス構造は変えません**（\`path.join(\".\")\` のまま）。後方互換性のため
- **Bidi / format control（\`U+202E\` 等）は意図的に残します**。i18n の正当なテキストを壊さないため。bidi-safe rendering はログレイヤーの責務
- **\`code\` フィールド**（Zod の issue code 等）もサニタイズ対象

### テスト (TDD)

各統合ごとに 1 件ずつ、同じ choke point を通ることを独立検証：

- **Z9** (zod.test.ts)
- **V9** (valibot.test.ts)
- **S9** (standard-schema.test.ts — valibot 経由の sValidator パスで StandardSchemaV1 issue mapping を exercise)

各テストは \`\\x01\` 付きのフィールド名を含むリクエストを送信し、レスポンスの \`errors[].field\` / \`errors[].message\` に C0/DEL が含まれないことをアサート。Red phase → Green phase 確認済み。

## Checklist

- [x] Tests added/updated (Z9, V9, S9)
- [x] \`pnpm test\` passes (181 passed)
- [x] Coverage 100%
- [x] \`pnpm typecheck\` passes
- [x] \`pnpm lint\` passes (with 1 \`biome-ignore\` comment on the regex, per spec)
- [x] Changeset added (patch)