### PR TITLE
chore(deps): split dependabot major bumps into individual PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,16 +7,25 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "Asia/Tokyo"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 15
     reviewers:
       - "paveg"
     labels:
       - "dependencies"
     groups:
+      # Bundle only minor/patch updates so they ship as one PR each.
+      # Major bumps fall through and get one PR per package — each
+      # major is independent risk and deserves independent review.
       dev-dependencies:
         dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
       production-dependencies:
         dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
     ignore:
       # Never auto-bump peer dep majors — those are coordinated with users
       - dependency-name: "hono"


### PR DESCRIPTION
## Summary

Updates `.github/dependabot.yml` so that Dependabot creates **one PR per major version bump** for dev / production dependencies, while still bundling minor / patch updates.

## Why

[#82](https://github.com/paveg/hono-problem-details/pull/82) bundled 13 dev dependency updates into a single PR. Of those, the following are major bumps:

- `@biomejs/biome` 1 → 2
- `zod` 3 → 4
- `vitest` 3 → 4
- `typescript` 5 → 6
- `@vitest/coverage-v8` 3 → 4
- `@hono/zod-openapi` 0.19 → 1.2
- `@hono/zod-validator` 0.5 → 0.7

Reviewing and rolling these back as a single unit is effectively impossible. Each major bump is independent risk and deserves its own PR. The previous dependabot config had no `update-types` filter on the groups, so minor / patch / major all funneled into the same group PR.

## Change

```yaml
groups:
  dev-dependencies:
    dependency-type: "development"
    update-types:        # NEW: keep majors out of the group
      - "minor"
      - "patch"
  production-dependencies:
    dependency-type: "production"
    update-types:        # NEW
      - "minor"
      - "patch"
```

`open-pull-requests-limit` is raised from `5` to `15` so individual major PRs have room to land in parallel.

## Effect

| Update type | Behavior |
|---|---|
| dev minor / patch | Bundled into one PR |
| prod minor / patch | Bundled into one PR |
| dev / prod major | **One PR per package** (independently reviewable) |
| `hono` major | Suppressed (`ignore` continues) |

## Follow-ups

After this lands:

1. Close [#82](https://github.com/paveg/hono-problem-details/pull/82) so the bundle gets re-created under the new rules
2. Wait for Dependabot's next scheduled run, or trigger it manually, to produce individual PRs
3. Review the resulting PRs one at a time

## Test plan

- [x] YAML syntax validated
- [ ] Configuration only — no source code changes
