### PR TITLE
chore(deps): declare optional peer dependencies for schema validators

### DIFF
--- a/.changeset/declare-optional-peers.md
+++ b/.changeset/declare-optional-peers.md
@@ -1,0 +1,30 @@
+---
+"hono-problem-details": minor
+---
+
+Properly declare optional peer dependencies for all schema validator integrations.
+
+The previous `package.json` listed schema validators in `peerDependenciesMeta`
+only, with no corresponding entries in `peerDependencies`. Per npm/pnpm/yarn
+semantics, `peerDependenciesMeta` provides metadata for entries in
+`peerDependencies` — without that anchor, the meta entries were dangling no-ops
+and users got no peer warnings for missing or incompatible installs of the
+schema validators they actually use.
+
+This release adds proper peer constraints (kept optional via the existing
+`peerDependenciesMeta`) for all seven schema validator integrations:
+
+- `zod` `^3.25.0` (matches `@hono/zod-validator@0.7.0+` peer requirement)
+- `valibot` `^1.0.0`
+- `@hono/zod-validator` `^0.7.5` (the version where hook return values are
+  correctly propagated to `zValidator`'s response)
+- `@hono/valibot-validator` `^0.6.0` (the version where the `Response` type
+  returned by hooks is properly respected)
+- `@hono/zod-openapi` `^0.19.0`
+- `@hono/standard-validator` `^0.2.0`
+- `@standard-schema/spec` `^1.0.0`
+
+Each peer remains optional, so consumers only see warnings for the integrations
+they actually install. Users on incompatible versions (e.g. `zod@3.20`,
+`@hono/zod-validator@0.5.x`) will now see peer dependency warnings from their
+package manager — update the relevant package to satisfy the constraint above.

--- a/package.json
+++ b/package.json
@@ -99,7 +99,14 @@
 	"license": "MIT",
 	"author": "Ryota Ikezawa",
 	"peerDependencies": {
-		"hono": ">=4.0.0"
+		"@hono/standard-validator": "^0.2.0",
+		"@hono/valibot-validator": "^0.6.0",
+		"@hono/zod-openapi": "^0.19.0",
+		"@hono/zod-validator": "^0.7.5",
+		"@standard-schema/spec": "^1.0.0",
+		"hono": ">=4.0.0",
+		"valibot": "^1.0.0",
+		"zod": "^3.25.0"
 	},
 	"peerDependenciesMeta": {
 		"@hono/zod-validator": {
@@ -140,7 +147,7 @@
 		"typescript": "^5.7.0",
 		"valibot": "^1.0.0",
 		"vitest": "^3.0.0",
-		"zod": "^3.24.0"
+		"zod": "^3.25.0"
 	},
 	"engines": {
 		"node": ">=20"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,7 +54,7 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(yaml@2.8.2)
       zod:
-        specifier: ^3.24.0
+        specifier: ^3.25.0
         version: 3.25.76
 
 packages:


### PR DESCRIPTION
## Summary

This PR fixes a long-standing metadata bug in `package.json`: the seven schema validator integrations were listed in `peerDependenciesMeta` only, with no corresponding entries in `peerDependencies`.

Per npm/pnpm/yarn semantics, `peerDependenciesMeta` is **metadata for entries in `peerDependencies`** — without that anchor, the meta entries are dangling no-ops. As a result, users got **zero peer warnings** for missing or incompatible installs of any schema validator they actually use.

## Before

```jsonc
"peerDependencies": {
  "hono": ">=4.0.0"
},
"peerDependenciesMeta": {
  "@hono/zod-validator":      { "optional": true },  // ← dangling
  "zod":                       { "optional": true },  // ← dangling
  "@hono/valibot-validator":  { "optional": true },  // ← dangling
  "valibot":                   { "optional": true },  // ← dangling
  "@hono/zod-openapi":         { "optional": true },  // ← dangling
  "@hono/standard-validator":  { "optional": true },  // ← dangling
  "@standard-schema/spec":     { "optional": true }   // ← dangling
}
```

All seven `peerDependenciesMeta` entries reference packages that aren't in `peerDependencies`, so npm/pnpm/yarn ignore them entirely.

## After

```jsonc
"peerDependencies": {
  "@hono/standard-validator": "^0.2.0",
  "@hono/valibot-validator":  "^0.6.0",
  "@hono/zod-openapi":         "^0.19.0",
  "@hono/zod-validator":      "^0.7.5",
  "@standard-schema/spec":     "^1.0.0",
  "hono":                      ">=4.0.0",
  "valibot":                   "^1.0.0",
  "zod":                       "^3.25.0"
},
"peerDependenciesMeta": { /* unchanged: each entry remains optional */ }
```

Each peer is kept optional via the existing `peerDependenciesMeta`, so consumers only see warnings for the integrations they actually install.

## How peer warnings work after this change

| User scenario | Behavior |
|---|---|
| `pnpm add hono-problem-details` (no validator) | No warning (all schema peers optional) |
| `pnpm add hono-problem-details zod@3.20` | **Warning: requires zod ^3.25.0** |
| `pnpm add hono-problem-details zod@3.25` | No warning |
| `pnpm add hono-problem-details valibot@1.3` | No warning |
| `pnpm add hono-problem-details valibot@0.30` | **Warning: requires valibot ^1.0.0** |
| `pnpm add hono-problem-details zod@3.25 valibot@1.3` | No warning (both used, both compatible) |

## Choice of version ranges

| Package | Range | Rationale |
|---|---|---|
| `zod` | `^3.25.0` | Matches `@hono/zod-validator@0.7.0+`'s own peer constraint |
| `valibot` | `^1.0.0` | 1.x is stable, semver-safe |
| `@hono/zod-validator` | `^0.7.5` | The release that fixed hook return value propagation, which `zodProblemHook` depends on |
| `@hono/valibot-validator` | `^0.6.0` | The release that respects the `Response` type returned by hooks |
| `@hono/zod-openapi` | `^0.19.0` | Lowest minor matching what is exercised in tests; v1.x is not yet tested |
| `@hono/standard-validator` | `^0.2.0` | Lowest minor matching what is exercised in tests |
| `@standard-schema/spec` | `^1.0.0` | 1.x is stable |

The dev-only `zod` range in `devDependencies` is also tightened from `^3.24.0` to `^3.25.0` so the local resolved version matches the new peer constraint.

## Breaking change classification

This is a `minor` changeset (v0.1.x → v0.2.0). Strictly speaking, no runtime behavior changes — but users who previously installed `hono-problem-details` alongside an incompatible schema validator version will now see new peer warnings from their package manager, which can fail strict CI configurations. That's a documented behavior change at the contract level, so a minor bump is the honest classification for a 0.x library.

## Test plan

- [x] `pnpm test` (189 passing across 10 files)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (local CI noise on `.claude/settings.local.json` is gitignored and doesn't reach CI)
- [x] `pnpm install` produced no spurious lockfile churn (only the updated zod specifier line)
- [x] Changeset added (`minor`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Officially declared optional peer dependencies for schema validator integrations including zod, valibot, and Hono validator packages. This improvement ensures package managers can provide clearer compatibility warnings when incompatible versions are installed, while maintaining these dependencies as optional for users who don't utilize these specific validators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->