### PR TITLE
docs: fix README inaccuracies

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Returns `application/problem+json` structured error responses with a single `app
 ## Features
 
 - **RFC 9457 compliant** — standard 5 fields + extension members
-- **Hono native** — `app.onError` handler + `createMiddleware()` patterns
+- **Hono native** — `app.onError` handler with RFC-compliant defaults
 - **Zod integration** — `@hono/zod-validator` hook for validation errors
 - **Valibot integration** — `@hono/valibot-validator` hook for validation errors
 - **OpenAPI integration** — `@hono/zod-openapi` schemas for API documentation
 - **Standard Schema** — `@hono/standard-validator` hook (works with any schema library)
 - **Type-safe** — full TypeScript support with inference
-- **Zero external dependencies** — only `hono` as peer dependency
+- **Zero runtime dependencies** — `hono` is the only required peer dependency; validator integrations are optional
 - **Localization** — `localize` callback for title/detail translation
 - **Edge-first** — works on Cloudflare Workers, Deno, Bun, and Node.js
 
@@ -33,6 +33,7 @@ npm install hono-problem-details
 
 ```ts
 import { Hono } from "hono";
+import { HTTPException } from "hono/http-exception";
 import { problemDetailsHandler } from "hono-problem-details";
 
 const app = new Hono();


### PR DESCRIPTION
## Summary
- Fix broken Quick Start example — `HTTPException` was used without being imported, so copy-pasting the first sample into a fresh project resulted in a `ReferenceError`.
- Correct the "Zero external dependencies" claim. Since #87 the package declares 7 optional peer dependencies for validator integrations (`zod`, `valibot`, `@hono/zod-validator`, `@hono/valibot-validator`, `@hono/zod-openapi`, `@hono/standard-validator`, `@standard-schema/spec`) in addition to the required `hono`. Reworded to "Zero runtime dependencies — `hono` is the only required peer dependency; validator integrations are optional".
- Drop the inaccurate "`createMiddleware()` patterns" feature bullet. The public API (`src/index.ts`) exposes `problemDetailsHandler` (an `ErrorHandler`) and validator hooks — no middleware built with `createMiddleware()`.

## Test plan
- [ ] CI green (docs-only change, no source/config touched)
- [ ] Rendered README preview verified on the PR page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified native error handling behavior, specifying RFC-compliant defaults for better standards alignment
  * Updated dependency documentation to accurately distinguish between zero runtime dependencies and peer dependency requirements, with validator integrations noted as optional
  * Enhanced the Quick Start code example with complete and proper import statements for users to reference when implementing the library

<!-- end of auto-generated comment: release notes by coderabbit.ai -->