### PR TITLE
docs: positioning overhaul — Why, Patterns, ADRs, llms.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,25 @@
 
 Returns `application/problem+json` structured error responses with a single `app.onError` setup.
 
+## Why hono-problem-details?
+
+Without a contract, HTTP error bodies drift. Every Hono project ends up reinventing the same
+scaffolding — and every client ends up parsing whatever shows up.
+
+- **Inconsistent shapes** across routes: `{ message }`, `{ error }`, `{ code, reason }`, or raw text
+- **Validation errors** from each schema library return a different format, so clients special-case each
+- **OpenAPI drift**: docs describe one error shape, the server returns another
+- **No standard for extensions**: adding `retryAfter` or `correlationId` means breaking your own contract
+
+[RFC 9457](https://www.rfc-editor.org/rfc/rfc9457.html) defines one structure — `{ type, status, title,
+detail, instance }` plus arbitrary extension members — and this middleware makes it the default for every
+error in your Hono app: thrown `ProblemDetailsError`, `HTTPException`, validation failures, and unhandled
+exceptions alike. One `app.onError()` line, one contract your clients, OpenAPI spec, and integration tests
+can all agree on.
+
 ## Features
 
-- **RFC 9457 compliant** — standard 5 fields + extension members
+- **RFC 9457 compliant** — `type`, `status`, `title`, `detail`, `instance` + extension members (flattened per §3.1, standard fields always win)
 - **Hono native** — `app.onError` handler with RFC-compliant defaults
 - **Zod integration** — `@hono/zod-validator` hook for validation errors
 - **Valibot integration** — `@hono/valibot-validator` hook for validation errors
@@ -55,21 +71,84 @@ app.get("/not-found", (c) => {
 // }
 ```
 
-## Throwing Problem Details
+## Patterns
+
+Common error shapes for day-to-day API work. Validation errors are covered separately by the
+[Zod](#zod-validator-integration) / [Valibot](#valibot-validator-integration) / [Standard Schema](#standard-schema-integration)
+hooks — this section is for errors you throw yourself.
 
 ```ts
 import { problemDetails } from "hono-problem-details";
+```
 
-app.post("/orders", (c) => {
-  throw problemDetails({
-    status: 409,
-    title: "Conflict",
-    detail: `Order ${id} already exists`,
-    type: "https://api.example.com/problems/order-conflict",
-    instance: `/orders/${id}`,
-  });
+### Unauthorized — 401
+
+```ts
+throw problemDetails({
+  status: 401,
+  title: "Unauthorized",
+  detail: "Missing or invalid credentials",
+  type: "https://api.example.com/problems/unauthorized",
 });
 ```
+
+Clients key off `type` to trigger a re-auth flow — no need to parse `detail`.
+
+### Forbidden — 403
+
+```ts
+throw problemDetails({
+  status: 403,
+  title: "Forbidden",
+  detail: `User ${userId} cannot access resource ${resourceId}`,
+  type: "https://api.example.com/problems/forbidden",
+  extensions: { requiredRole: "admin" },
+});
+```
+
+### Not Found — 404
+
+```ts
+throw problemDetails({
+  status: 404,
+  title: "Not Found",
+  detail: `Order ${orderId} does not exist`,
+  instance: `/orders/${orderId}`,
+});
+```
+
+`instance` points at the specific occurrence — clients can use it as a key for retry logic
+or deduplication.
+
+### Conflict — 409
+
+```ts
+throw problemDetails({
+  status: 409,
+  title: "Order Conflict",
+  detail: `Order ${orderId} already exists`,
+  type: "https://api.example.com/problems/order-conflict",
+  instance: `/orders/${orderId}`,
+});
+```
+
+Domain conflicts should always carry a project-specific `type` URI. `about:blank` is fine for
+generic 4xx/5xx but loses its value the moment a client needs to distinguish two conflicts.
+
+### Too Many Requests — 429
+
+```ts
+throw problemDetails({
+  status: 429,
+  title: "Too Many Requests",
+  detail: "Request quota exceeded",
+  type: "https://api.example.com/problems/rate-limited",
+  extensions: { retryAfter: 60, quota: 1000, remaining: 0 },
+});
+```
+
+Rate-limit metadata goes in `extensions` — clients read it straight from the body instead
+of juggling `Retry-After` headers.
 
 ## Extension Members
 
@@ -128,6 +207,16 @@ throw problems.create("RATE_LIMITED", {
   extensions: { retryAfter: 60 },
 });
 ```
+
+### When to use the registry vs `problemDetails()`
+
+Reach for `createProblemTypeRegistry` when your API has a fixed set of domain errors and you
+want one source of truth for `type` / `status` / `title`. It pays off the moment the same error
+is thrown from more than one handler — renames and URI changes happen in one place.
+
+Use `problemDetails()` directly for one-off errors, prototypes, or generic 4xx/5xx where
+`about:blank` is the right `type`. RFC 9457 explicitly allows `about:blank` when the HTTP status
+code alone is enough context — don't force a URI just to have one.
 
 ## Zod Validator Integration
 
@@ -258,6 +347,16 @@ problemDetailsHandler({
 ```
 
 The callback receives the fully-built `ProblemDetails` object and the Hono `Context`, allowing access to headers like `Accept-Language`. Return a new `ProblemDetails` with translated fields.
+
+> **Note on caching**: If your responses vary by `Accept-Language`, add `Vary: Accept-Language`
+> from your own middleware so CDNs and browser caches don't serve the wrong translation.
+> This middleware intentionally does not set `Vary` — error handlers shouldn't mutate
+> request-scope headers that also apply to successful responses.
+
+> **Note on failures**: If your `localize` callback throws, the handler falls back to the
+> un-localized `ProblemDetails` and continues. Throwing from inside `app.onError` would cause
+> the error handler to re-enter itself, so the swallow is deliberate. Catch errors inside your
+> callback if you need to observe them.
 
 ## Handler Options
 

--- a/docs/adr/0001-provide-both-registry-and-inline-apis.md
+++ b/docs/adr/0001-provide-both-registry-and-inline-apis.md
@@ -1,0 +1,56 @@
+# ADR-0001: Provide both registry and inline APIs for problem type construction
+
+## Status
+
+Accepted
+
+## Context
+
+RFC 9457 §4 defines a Problem Type as a URI-identified category of errors. Two design
+patterns are common for how applications define these:
+
+1. **Inline construction**: every throw site writes out the full `{ type, status, title, ... }` literal
+2. **Centralized registry**: a single source of truth for all problem types, with throw sites referencing keys
+
+Inline-only APIs optimize for first-use simplicity but cause drift once the same error
+is thrown from more than one handler — `type` URIs get misspelled, `status` / `title`
+pairs drift out of sync, and renames require grepping the codebase.
+
+Registry-only APIs optimize for consistency but impose overhead on one-off errors,
+prototypes, and generic 4xx / 5xx cases where `about:blank` is the correct `type`. Forcing
+a registry entry for every throw creates meaningless ceremony, and RFC 9457 explicitly
+allows `about:blank` when the HTTP status code alone is sufficient context.
+
+## Decision
+
+This middleware ships **both** APIs, deliberately unranked:
+
+- `problemDetails(input)` — inline factory, returns a `ProblemDetailsError` instance
+- `createProblemTypeRegistry(definitions)` — factory for a typed registry, returns a
+  `.create(key, options)` method
+
+The README guidance points users to the registry when the same error is thrown from more
+than one handler, and to the inline factory otherwise. `createProblemTypeRegistry` builds
+on top of `problemDetails` internally (see `src/registry.ts`), so the registry is a strict
+superset of the inline API — no code duplication.
+
+Neither API requires the other. A project can adopt `problemDetails()` alone and never
+touch the registry, or vice versa.
+
+## Consequences
+
+**Positive**:
+
+- Low friction for first use: `throw problemDetails({ status: 404, title: "Not Found" })`
+  works without setup
+- No ceremony for prototypes or truly one-off errors
+- Registry users get typed keys, IDE autocomplete, and single-source-of-truth for
+  `type` / `status` / `title`
+- Migrating from inline to registry is additive — existing throws keep working
+
+**Negative**:
+
+- Two ways to do the same thing. Users must read the README to know which fits their case
+- The registry API is discoverable only via the README or docs; there is no lint rule
+  that pushes users toward it when repetition emerges
+- Mixing both patterns in one codebase is technically possible and may confuse readers

--- a/docs/adr/0002-extension-flatten-with-standard-field-precedence.md
+++ b/docs/adr/0002-extension-flatten-with-standard-field-precedence.md
@@ -1,0 +1,61 @@
+# ADR-0002: Flatten extension members at top level with standard-field precedence
+
+## Status
+
+Accepted
+
+## Context
+
+RFC 9457 §3.2 defines extension members as additional keys on a Problem Details object
+beyond the five standard fields (`type`, `status`, `title`, `detail`, `instance`). The spec
+requires that extension members appear at the top level of the JSON object, not nested
+under a separate key.
+
+The middleware exposes extensions via a dedicated `extensions` field on the
+`ProblemDetailsInput` interface to avoid a typing hazard: if users wrote extensions
+directly alongside standard fields on a single object, the TypeScript type for extensions
+would need to be `Record<string, unknown>` merged with the standard fields — inference
+would collapse and accidental overrides of `status` / `title` would compile silently.
+
+This creates a serialization problem: how do we flatten
+`{ type, status, ..., extensions: { foo } }` into `{ type, status, ..., foo }` on the wire,
+and what happens if an extension key collides with a standard field name
+(e.g. `extensions: { status: 999 }`)?
+
+## Decision
+
+`buildProblemResponse` in `src/utils.ts` performs the flatten with this spread order:
+
+```ts
+const { extensions, ...standard } = pd;
+const body = { ...sanitizeExtensions(extensions), ...standard };
+```
+
+Standard fields are spread **after** extensions, so they always win when keys collide.
+Extension keys that match a standard field name are silently dropped from the output.
+This matches RFC 9457 §3.1's requirement that the five standard members have fixed
+semantics — users cannot override them through the extensions channel.
+
+Additionally, `sanitizeExtensions` strips the prototype pollution keys `__proto__`,
+`constructor`, and `prototype` before the spread, to prevent downstream JSON consumers
+that use `Object.assign` or spread on the parsed body from being affected.
+
+## Consequences
+
+**Positive**:
+
+- Typed `ProblemDetailsInput.extensions` keeps inference clean for the caller
+- RFC 9457 §3.1 compliance is enforced mechanically by the spread order — no runtime
+  check required
+- Prototype pollution keys are dropped at the serialization boundary, not pushed onto
+  consumers
+- The behavior is testable with a single assertion: `extensions: { status: 999 }` must
+  not change the response status
+
+**Negative**:
+
+- Silent override suppression may surprise users who expect `extensions: { status: 999 }`
+  to either error or take effect
+- Prototype key stripping is not logged, so malformed input is hidden from operators
+- Users who want a truly nested `extensions` field in the response body (non-RFC-compliant)
+  have no escape hatch

--- a/docs/adr/0003-swallow-exceptions-from-localize-callback.md
+++ b/docs/adr/0003-swallow-exceptions-from-localize-callback.md
@@ -1,0 +1,71 @@
+# ADR-0003: Swallow exceptions from the localize callback
+
+## Status
+
+Accepted
+
+## Context
+
+The `problemDetailsHandler` accepts a `localize(pd, c)` callback that translates
+`title` and `detail` based on the request context (typically `Accept-Language`). The
+callback is user-provided code running inside `app.onError`, and it can throw.
+
+Three options exist for handling a thrown `localize` callback:
+
+1. **Propagate the throw** — let the `onError` handler fail, which causes Hono to re-enter
+   `onError` with the new error, potentially looping
+2. **Return a 500 directly** — abandon the original problem details and return an internal
+   server error
+3. **Fall back to the un-localized ProblemDetails** — ignore the callback failure and continue
+
+Option 1 is dangerous: Hono's `app.onError` re-entry semantics mean a throwing error
+handler can produce an infinite loop or an unhelpful "error in error handler" response.
+This is a well-known footgun for Node.js and Hono error middleware.
+
+Option 2 loses the original error context. A 404 with a broken Japanese translation
+becoming a 500 "Internal Server Error" erases the user-visible information that the
+client actually needed.
+
+Option 3 preserves the original error, sacrifices only the translation, and avoids
+re-entry — but it silently hides localize bugs from operators.
+
+## Decision
+
+`src/handler.ts` wraps the `localize` call in a try/catch and falls back to the
+un-localized `ProblemDetails` on any thrown error:
+
+```ts
+if (options.localize) {
+  try {
+    pd = { ...pd, ...options.localize(pd, c) };
+  } catch {
+    // Fall through with the un-localized pd. A throwing localize must not
+    // cause the error handler itself to throw — that would re-enter onError.
+  }
+}
+```
+
+The swallow is documented in the README's Localization section so users know the
+fallback exists. Users who need to observe localize failures are directed to catch
+errors inside their callback and report them explicitly (logging, Sentry, etc.).
+
+## Consequences
+
+**Positive**:
+
+- `app.onError` cannot re-enter itself because of a translation bug
+- The original error shape — `status`, `type`, `title`, `detail` — is preserved even if
+  translation fails
+- No special machinery required: the callback contract is "return a translated
+  `ProblemDetails`, or throw and get ignored"
+
+**Negative**:
+
+- Localize bugs are invisible to operators unless the user-provided callback reports
+  them internally
+- Users cannot opt out of the swallow — there's no option like
+  `onLocalizeError: "throw" | "swallow"`. If a future use case emerges, it would need a
+  new option
+- The README note about the swallow is the only surface where this behavior is
+  documented. Users who don't read the README may be confused when translations silently
+  disappear

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,197 @@
+# hono-problem-details
+
+> RFC 9457 Problem Details middleware for Hono. Returns `application/problem+json`
+> structured error responses with a single `app.onError()` setup.
+
+This file is an LLM-focused quick reference. For the full documentation see the
+[README](https://github.com/paveg/hono-problem-details#readme).
+
+## When to use
+
+- Your Hono API needs a consistent error response format across all routes
+- Clients (mobile apps, SDKs, TypeScript clients) parse error responses programmatically
+- You document errors in OpenAPI and want server responses to match the spec
+- You need typed error categories for domain errors (conflict, rate limit, auth)
+
+## Setup
+
+```ts
+import { Hono } from "hono";
+import { problemDetailsHandler } from "hono-problem-details";
+
+const app = new Hono();
+
+app.onError(problemDetailsHandler());
+```
+
+Every thrown error — `ProblemDetailsError`, Hono's `HTTPException`, validation failures,
+and unhandled exceptions — is returned as `application/problem+json; charset=utf-8`.
+
+## Throwing errors
+
+Use `problemDetails()` for inline throws. Fill in `type` with a project-specific URI
+when clients need to distinguish sub-categories of the same HTTP status; otherwise leave
+`type` unset and the default `"about:blank"` will be used.
+
+```ts
+import { problemDetails } from "hono-problem-details";
+
+// 401 Unauthorized
+throw problemDetails({
+  status: 401,
+  title: "Unauthorized",
+  detail: "Missing or invalid credentials",
+  type: "https://api.example.com/problems/unauthorized",
+});
+
+// 403 Forbidden with extension metadata
+throw problemDetails({
+  status: 403,
+  title: "Forbidden",
+  detail: `User ${userId} cannot access ${resourceId}`,
+  type: "https://api.example.com/problems/forbidden",
+  extensions: { requiredRole: "admin" },
+});
+
+// 404 Not Found with instance URI
+throw problemDetails({
+  status: 404,
+  title: "Not Found",
+  detail: `Order ${orderId} does not exist`,
+  instance: `/orders/${orderId}`,
+});
+
+// 409 Conflict (domain error)
+throw problemDetails({
+  status: 409,
+  title: "Order Conflict",
+  detail: `Order ${orderId} already exists`,
+  type: "https://api.example.com/problems/order-conflict",
+  instance: `/orders/${orderId}`,
+});
+
+// 429 Too Many Requests with rate-limit metadata
+throw problemDetails({
+  status: 429,
+  title: "Too Many Requests",
+  detail: "Request quota exceeded",
+  type: "https://api.example.com/problems/rate-limited",
+  extensions: { retryAfter: 60, quota: 1000, remaining: 0 },
+});
+```
+
+Use `createProblemTypeRegistry()` when the same error is thrown from multiple handlers
+and you want one source of truth for `type` / `status` / `title`:
+
+```ts
+import { createProblemTypeRegistry } from "hono-problem-details";
+
+const problems = createProblemTypeRegistry({
+  ORDER_CONFLICT: {
+    type: "https://api.example.com/problems/order-conflict",
+    status: 409,
+    title: "Order Conflict",
+  },
+  RATE_LIMITED: {
+    type: "https://api.example.com/problems/rate-limited",
+    status: 429,
+    title: "Too Many Requests",
+  },
+});
+
+throw problems.create("ORDER_CONFLICT", {
+  detail: `Order ${orderId} already exists`,
+  instance: `/orders/${orderId}`,
+});
+```
+
+## Validation errors
+
+Validation errors are automatically converted to 422 Unprocessable Content with an
+`errors` extension member. Use the matching hook for your schema library:
+
+```ts
+// Zod
+import { zValidator } from "@hono/zod-validator";
+import { zodProblemHook } from "hono-problem-details/zod";
+
+app.post("/users", zValidator("json", schema, zodProblemHook()), handler);
+
+// Valibot
+import { vValidator } from "@hono/valibot-validator";
+import { valibotProblemHook } from "hono-problem-details/valibot";
+
+app.post("/users", vValidator("json", schema, valibotProblemHook()), handler);
+
+// Any Standard Schema library (Zod, Valibot, ArkType, etc.)
+import { sValidator } from "@hono/standard-validator";
+import { standardSchemaProblemHook } from "hono-problem-details/standard-schema";
+
+app.post("/users", sValidator("json", schema, standardSchemaProblemHook()), handler);
+```
+
+Validation error response shape:
+
+```json
+{
+  "type": "about:blank",
+  "status": 422,
+  "title": "Validation Error",
+  "detail": "Request validation failed",
+  "errors": [
+    { "field": "email", "message": "Invalid email", "code": "invalid_string" }
+  ]
+}
+```
+
+## Response shape (RFC 9457)
+
+```json
+{
+  "type": "https://api.example.com/problems/order-conflict",
+  "status": 409,
+  "title": "Order Conflict",
+  "detail": "Order abc-123 already exists",
+  "instance": "/orders/abc-123",
+  "retryAfter": 60
+}
+```
+
+Standard fields:
+
+- `type` — URI identifying the problem type. Use `"about:blank"` (default) when the HTTP
+  status alone is sufficient context
+- `status` — HTTP status code, 200–599 (clamped to 500 if invalid)
+- `title` — short human-readable summary, stable across occurrences
+- `detail` — specific to this occurrence, may include dynamic values
+- `instance` — URI identifying this specific occurrence
+
+Extension members (e.g. `retryAfter` in the example above) are passed via the
+`extensions` field on the input, and are flattened to the top level of the response body
+per RFC 9457 §3.1.
+
+Content-Type: `application/problem+json; charset=utf-8`
+
+## Rules and gotchas
+
+- **Don't force a `type` URI for every error.** RFC 9457 allows `"about:blank"` when the
+  HTTP status is enough context. Force a project-specific URI only when clients need to
+  distinguish sub-categories (e.g. two different 409 conflicts).
+- **Extensions are flattened, not nested.** Passing `extensions: { foo: 1 }` puts
+  `"foo": 1` at the top level of the response, not nested under `"extensions"`.
+- **Extension keys cannot override standard fields.** If you pass
+  `extensions: { status: 999 }`, it is silently dropped — standard `status` always wins.
+- **Prototype pollution keys are stripped.** `__proto__`, `constructor`, and `prototype`
+  are removed from extension members before serialization.
+- **`Accept-Language` responses need `Vary`.** If you use the `localize` option, add
+  `Vary: Accept-Language` from your own middleware. This library does not set it.
+- **`localize` throws are swallowed.** If your `localize` callback throws, the handler
+  falls back to the un-localized `ProblemDetails`. Throwing from inside `app.onError`
+  would cause re-entry, so this is deliberate. Catch errors inside your callback if you
+  need to observe them.
+
+## See also
+
+- [README](https://github.com/paveg/hono-problem-details#readme) — full API reference, Handler Options, OpenAPI integration
+- [ADRs](https://github.com/paveg/hono-problem-details/tree/main/docs/adr) — design decisions
+- [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457.html) — Problem Details for HTTP APIs specification


### PR DESCRIPTION
## Summary

- **README restructure** — add `## Why hono-problem-details?` before Features, a `## Patterns` cookbook (401 / 403 / 404 / 409 / 429), a `### When to use the registry vs problemDetails()` subsection, and two notes on the Localization section (`Vary` header requirement, `localize` silent-swallow behavior). Drops the redundant `## Throwing Problem Details` section now subsumed by Patterns.
- **3 ADRs** in a new `docs/adr/` directory codifying the non-obvious design decisions surfaced by reading `src/`: inline vs registry coexistence (0001), RFC 9457 §3.1 extension flatten with standard-field precedence (0002), and the intentional `localize` silent-swallow to avoid `onError` re-entry (0003).
- **`llms.txt`** at the repo root with inline patterns and a rules-and-gotchas summary, so LLM-generated code can quote correct patterns without fetching the full README.

No source changes — docs only. README grows from 301 to 400 lines (33%); the bulk of the growth is the Patterns cookbook.

## Test plan

- [x] `pnpm lint` — clean (after auto-fix on pre-existing `.claude/settings.local.json`, gitignored)
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 189 / 189 passing
- [ ] README renders correctly on GitHub — Patterns code blocks, Note blockquotes, anchor links to integration sections
- [ ] `docs/adr/` renders as a navigable directory listing on GitHub
- [ ] `llms.txt` is accessible at the raw URL after merge for LLM tooling to consume

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced README with problem motivations, concrete code examples for common HTTP error scenarios, guidance on selecting between API styles, and localization best practices
  * Added three architecture decision records documenting the dual API contract, extension field flattening and collision handling, and localization exception behavior
  * Introduced LLM-focused quick reference guide for rapid middleware integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->