### PR TITLE
docs: add TSDoc to all public API symbols

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -1,9 +1,19 @@
 import type { ProblemDetails, ProblemDetailsInput } from "./types.js";
 import { buildProblemResponse, normalizeProblemDetails } from "./utils.js";
 
+/**
+ * Error class for RFC 9457 Problem Details.
+ * Thrown by {@link problemDetails} and caught by the handler to produce
+ * `application/problem+json` responses.
+ */
 export class ProblemDetailsError extends Error {
+	/** The normalized RFC 9457 Problem Details object. */
 	readonly problemDetails: ProblemDetails;
 
+	/**
+	 * @param input - Missing `type` defaults to `"about:blank"`;
+	 * missing `title` is derived from the HTTP status code.
+	 */
 	constructor(input: ProblemDetailsInput) {
 		const pd = normalizeProblemDetails(input);
 		super(pd.detail ?? pd.title);
@@ -11,6 +21,7 @@ export class ProblemDetailsError extends Error {
 		this.problemDetails = pd;
 	}
 
+	/** Build a standalone `application/problem+json` Response without the handler middleware. */
 	getResponse(): Response {
 		return buildProblemResponse(this.problemDetails);
 	}

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -1,6 +1,18 @@
 import { ProblemDetailsError } from "./error.js";
 import type { ProblemDetailsInput } from "./types.js";
 
+/**
+ * Create a {@link ProblemDetailsError} from the given input.
+ * Missing `type` defaults to `"about:blank"`; missing `title` is derived from the status code.
+ *
+ * @example
+ * ```ts
+ * throw problemDetails({
+ *   status: 404,
+ *   detail: `Order ${orderId} does not exist`,
+ * });
+ * ```
+ */
 export function problemDetails<T extends Record<string, unknown>>(
 	input: ProblemDetailsInput<T>,
 ): ProblemDetailsError {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -34,6 +34,19 @@ function toResponse(
 	return buildProblemResponse(pd);
 }
 
+/**
+ * Create an `app.onError` handler that returns RFC 9457 Problem Details responses.
+ * Handles {@link ProblemDetailsError}, Hono `HTTPException`, and unhandled exceptions.
+ *
+ * @example
+ * ```ts
+ * import { Hono } from "hono";
+ * import { problemDetailsHandler } from "hono-problem-details";
+ *
+ * const app = new Hono();
+ * app.onError(problemDetailsHandler());
+ * ```
+ */
 export function problemDetailsHandler(options: ProblemDetailsHandlerOptions = {}): ErrorHandler {
 	return (error, c) => {
 		if (error instanceof ProblemDetailsError) {

--- a/src/integrations/standard-schema.ts
+++ b/src/integrations/standard-schema.ts
@@ -21,6 +21,11 @@ function formatIssues(issues: readonly StandardSchemaV1.Issue[]): ValidationErro
 	}));
 }
 
+/**
+ * Create a `@hono/standard-validator` hook that returns RFC 9457 Problem Details
+ * on validation failure (422 Unprocessable Content with `errors` extension).
+ * Works with any Standard Schema-compatible library (Zod, Valibot, ArkType, etc.).
+ */
 export function standardSchemaProblemHook(
 	options?: ValidationHookOptions,
 ): (

--- a/src/integrations/valibot.ts
+++ b/src/integrations/valibot.ts
@@ -16,6 +16,10 @@ function formatIssues(issues: BaseIssue<unknown>[]): ValidationError[] {
 	}));
 }
 
+/**
+ * Create a `@hono/valibot-validator` hook that returns RFC 9457 Problem Details
+ * on validation failure (422 Unprocessable Content with `errors` extension).
+ */
 export function valibotProblemHook<T extends GenericSchema | GenericSchemaAsync = GenericSchema>(
 	options?: ValidationHookOptions,
 ): (result: SafeParseResult<T> & { target: string }, c: Context) => Response | undefined {

--- a/src/integrations/zod.ts
+++ b/src/integrations/zod.ts
@@ -16,6 +16,10 @@ function formatErrors(zodError: ZodError): ValidationError[] {
 	}));
 }
 
+/**
+ * Create a `@hono/zod-validator` hook that returns RFC 9457 Problem Details
+ * on validation failure (422 Unprocessable Content with `errors` extension).
+ */
 export function zodProblemHook(
 	options?: ValidationHookOptions,
 ): (

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -13,17 +13,32 @@ interface CreateOptions<T extends Record<string, unknown> = Record<string, unkno
 }
 
 interface ProblemTypeRegistry<K extends string> {
+	/** Create a {@link ProblemDetailsError} from a registered problem type key. */
 	create: <T extends Record<string, unknown>>(
 		key: K,
 		options?: CreateOptions<T>,
 	) => ProblemDetailsError;
+	/** Get the base definition (type, status, title) for a registered key. */
 	get: (key: K) => ProblemTypeDefinition;
+	/** List all registered problem type keys. */
 	types: () => K[];
 }
 
 /**
  * Create a registry of pre-defined problem types.
  * Provides type-safe error creation from registered definitions.
+ *
+ * @example
+ * ```ts
+ * const problems = createProblemTypeRegistry({
+ *   ORDER_CONFLICT: {
+ *     type: "https://api.example.com/problems/order-conflict",
+ *     status: 409,
+ *     title: "Order Conflict",
+ *   },
+ * });
+ * throw problems.create("ORDER_CONFLICT", { detail: "Already exists" });
+ * ```
  */
 export function createProblemTypeRegistry<K extends string>(
 	definitions: Record<K, ProblemTypeDefinition>,

--- a/src/status.ts
+++ b/src/status.ts
@@ -52,10 +52,12 @@ const STATUS_SLUGS: Record<number, string> = Object.fromEntries(
 	]),
 );
 
+/** Look up the standard HTTP reason phrase for a status code (e.g. 404 → `"Not Found"`). */
 export function statusToPhrase(status: number): string | undefined {
 	return STATUS_PHRASES[status];
 }
 
+/** Look up a URL-safe slug for a status code (e.g. 404 → `"not-found"`). Used by the `typePrefix` handler option. */
 export function statusToSlug(status: number): string | undefined {
 	return STATUS_SLUGS[status];
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import { statusToPhrase } from "./status.js";
 import type { ProblemDetails, ProblemDetailsInput } from "./types.js";
 
+/** RFC 9457 media type: `application/problem+json; charset=utf-8`. */
 export const PROBLEM_JSON_CONTENT_TYPE = "application/problem+json; charset=utf-8";
 
 const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);


### PR DESCRIPTION
## Summary

- Add JSDoc/TSDoc comments to every exported symbol that lacked them (9 files, +67 lines)
- These flow into the published `.d.ts` files via tsup (`dts: true`) and appear in editor hover tooltips for end users
- Main gap closed: the three most-used APIs (`problemDetails()`, `problemDetailsHandler()`, `ProblemDetailsError`) had zero hover documentation

Newly documented symbols:

| File | Symbol |
|---|---|
| `error.ts` | `ProblemDetailsError` class + constructor + `getResponse()` |
| `factory.ts` | `problemDetails()` with `@example` |
| `handler.ts` | `problemDetailsHandler()` with `@example` |
| `registry.ts` | `ProblemTypeRegistry<K>` methods (create/get/types) + `@example` on `createProblemTypeRegistry()` |
| `status.ts` | `statusToPhrase()` / `statusToSlug()` |
| `utils.ts` | `PROBLEM_JSON_CONTENT_TYPE` |
| `integrations/zod.ts` | `zodProblemHook()` |
| `integrations/valibot.ts` | `valibotProblemHook()` |
| `integrations/standard-schema.ts` | `standardSchemaProblemHook()` |

Already covered (not touched): `types.ts` (3 interfaces), `integrations/openapi.ts` (3 exports).

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 189 / 189 passing
- [x] `pnpm build` — verified TSDoc comments appear in `dist/index.d.ts` and `dist/index.d.cts`
- [ ] Verify editor hover shows docs when importing `problemDetails`, `problemDetailsHandler`, `ProblemDetailsError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded documentation across all modules with comprehensive JSDoc comments, detailed function descriptions, and practical usage examples for public APIs, utility functions, error handlers, validation integration hooks, registry management, and status code lookup utilities to provide enhanced developer reference and improved code maintainability throughout the library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->