### PR TITLE
chore: exclude source maps from tarball, add funding and hot-path benchmarks

### DIFF
--- a/benchmarks/core.bench.ts
+++ b/benchmarks/core.bench.ts
@@ -1,0 +1,153 @@
+import { bench, describe } from "vitest";
+import { ProblemDetailsError } from "../src/error.js";
+import type { ProblemDetails } from "../src/types.js";
+import {
+	buildProblemResponse,
+	clampHttpStatus,
+	normalizeProblemDetails,
+	safeStringify,
+	sanitizeExtensions,
+} from "../src/utils.js";
+
+// ── normalizeProblemDetails ─────────────────────────────────────────
+
+describe("normalizeProblemDetails", () => {
+	bench("minimal input (status only)", () => {
+		normalizeProblemDetails({ status: 404 });
+	});
+
+	bench("full input (all fields)", () => {
+		normalizeProblemDetails({
+			status: 409,
+			type: "https://api.example.com/problems/order-conflict",
+			title: "Order Conflict",
+			detail: "Order abc-123 already exists",
+			instance: "/orders/abc-123",
+		});
+	});
+
+	bench("with extensions", () => {
+		normalizeProblemDetails({
+			status: 429,
+			title: "Too Many Requests",
+			extensions: { retryAfter: 60, quota: 1000, remaining: 0 },
+		});
+	});
+});
+
+// ── sanitizeExtensions ──────────────────────────────────────────────
+
+describe("sanitizeExtensions", () => {
+	const clean = { retryAfter: 60, quota: 1000, remaining: 0 };
+	const dirty = { retryAfter: 60, constructor: "foo", prototype: "bar" };
+
+	bench("no dangerous keys (common path)", () => {
+		sanitizeExtensions(clean);
+	});
+
+	bench("with dangerous keys (rare path)", () => {
+		sanitizeExtensions(dirty);
+	});
+
+	bench("undefined extensions", () => {
+		sanitizeExtensions(undefined);
+	});
+});
+
+// ── clampHttpStatus ─────────────────────────────────────────────────
+
+describe("clampHttpStatus", () => {
+	bench("valid status", () => {
+		clampHttpStatus(404);
+	});
+
+	bench("out of range", () => {
+		clampHttpStatus(999);
+	});
+
+	bench("non-integer", () => {
+		clampHttpStatus(404.5);
+	});
+});
+
+// ── safeStringify ───────────────────────────────────────────────────
+
+describe("safeStringify", () => {
+	const small = { type: "about:blank", status: 404, title: "Not Found" };
+	const medium = {
+		type: "about:blank",
+		status: 422,
+		title: "Validation Error",
+		detail: "Request validation failed",
+		errors: Array.from({ length: 10 }, (_, i) => ({
+			field: `field_${i}`,
+			message: `Error message for field ${i}`,
+			code: "invalid_type",
+		})),
+	};
+
+	bench("small payload (~80 bytes)", () => {
+		safeStringify(small);
+	});
+
+	bench("medium payload (10 validation errors)", () => {
+		safeStringify(medium);
+	});
+});
+
+// ── buildProblemResponse (end-to-end serialization) ─────────────────
+
+describe("buildProblemResponse", () => {
+	const minimal: ProblemDetails = {
+		type: "about:blank",
+		status: 404,
+		title: "Not Found",
+	};
+
+	const withDetail: ProblemDetails = {
+		type: "about:blank",
+		status: 404,
+		title: "Not Found",
+		detail: "Order abc-123 does not exist",
+		instance: "/orders/abc-123",
+	};
+
+	const withExtensions: ProblemDetails = {
+		type: "https://api.example.com/problems/rate-limited",
+		status: 429,
+		title: "Too Many Requests",
+		detail: "Request quota exceeded",
+		extensions: { retryAfter: 60, quota: 1000, remaining: 0 },
+	};
+
+	bench("minimal (no detail, no extensions)", () => {
+		buildProblemResponse(minimal);
+	});
+
+	bench("with detail and instance", () => {
+		buildProblemResponse(withDetail);
+	});
+
+	bench("with extensions (flatten + sanitize + stringify)", () => {
+		buildProblemResponse(withExtensions);
+	});
+});
+
+// ── ProblemDetailsError construction ────────────────────────────────
+
+describe("ProblemDetailsError", () => {
+	bench("construct with minimal input", () => {
+		new ProblemDetailsError({ status: 404 });
+	});
+
+	bench("construct with full input + extensions", () => {
+		new ProblemDetailsError({
+			status: 409,
+			type: "https://api.example.com/problems/order-conflict",
+			title: "Order Conflict",
+			detail: "Order abc-123 already exists",
+			instance: "/orders/abc-123",
+			extensions: { retryAfter: 60 },
+		});
+	});
+});

--- a/package.json
+++ b/package.json
@@ -66,11 +66,12 @@
 			"standard-schema": ["./dist/integrations/standard-schema.d.ts"]
 		}
 	},
-	"files": ["dist"],
+	"files": ["dist", "!dist/**/*.map"],
 	"sideEffects": false,
 	"scripts": {
 		"build": "tsup",
 		"test": "vitest run",
+		"bench": "vitest bench",
 		"test:watch": "vitest",
 		"lint": "biome check .",
 		"lint:fix": "biome check --write .",
@@ -98,6 +99,7 @@
 	"bugs": "https://github.com/paveg/hono-problem-details/issues",
 	"license": "MIT",
 	"author": "Ryota Ikezawa",
+	"funding": "https://github.com/sponsors/paveg",
 	"peerDependencies": {
 		"@hono/standard-validator": "^0.2.0",
 		"@hono/valibot-validator": "^0.6.0",


### PR DESCRIPTION
## Summary

- **Exclude source maps from npm tarball** — add `!dist/**/*.map` to `files` field. Source maps are still generated (available from repo/jsDelivr) but no longer bloat the npm download. ~64KB reduction.
- **Add `funding` field** — mirrors `.github/FUNDING.yml` so npm's package page shows the "Fund this package" button.
- **Add `bench` script** — `vitest bench` for running benchmarks.
- **Add hot-path benchmarks** — new `benchmarks/core.bench.ts` covering every function on the error → JSON → Response pipeline:

| Function | ops/sec | µs/op |
|---|---|---|
| `buildProblemResponse` (minimal) | 562K | 1.8 |
| `buildProblemResponse` (with extensions) | 484K | 2.1 |
| `ProblemDetailsError` (minimal) | 513K | 1.9 |
| `ProblemDetailsError` (full + extensions) | 475K | 2.1 |
| `normalizeProblemDetails` | 24-40M | <0.1 |
| `sanitizeExtensions` (common path) | 24M | <0.1 |
| `clampHttpStatus` | 41M | <0.1 |
| `safeStringify` (small) | 7.2M | 0.1 |

Bottleneck is `buildProblemResponse` at ~500K ops/sec due to object spread + JSON.stringify + Response construction. This is well within budget for an error handler.

## Test plan

- [x] `pnpm lint` — clean (32 files)
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 189 / 189 passing
- [x] `pnpm bench` — all benchmarks pass
- [x] `npm pack --dry-run` — verified 0 `.map` files in tarball (28 files, down from 41)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added performance benchmarks for core utility functions to measure and track performance characteristics.

* **Chores**
  * Updated npm package distribution configuration to exclude source map files.
  * Added repository funding information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->