### PR TITLE
docs: add download/size/stars badges and star CTA to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # hono-problem-details
 
 [![npm version](https://img.shields.io/npm/v/hono-problem-details)](https://www.npmjs.com/package/hono-problem-details)
+[![npm downloads](https://img.shields.io/npm/dw/hono-problem-details)](https://www.npmjs.com/package/hono-problem-details)
+[![bundle size](https://img.shields.io/bundlephobia/minzip/hono-problem-details)](https://bundlephobia.com/package/hono-problem-details)
+[![GitHub stars](https://img.shields.io/github/stars/paveg/hono-problem-details?style=flat)](https://github.com/paveg/hono-problem-details/stargazers)
 [![CI](https://github.com/paveg/hono-problem-details/actions/workflows/ci.yml/badge.svg)](https://github.com/paveg/hono-problem-details/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/paveg/hono-problem-details?utm_source=oss&utm_medium=github&utm_campaign=paveg%2Fhono-problem-details&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)](https://coderabbit.ai)
@@ -9,6 +12,8 @@
 [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457.html) Problem Details middleware for [Hono](https://hono.dev).
 
 Returns `application/problem+json` structured error responses with a single `app.onError` setup.
+
+> If this saved you from hand-rolling RFC 9457 in yet another Hono project, please [⭐ star the repo](https://github.com/paveg/hono-problem-details) — it helps others discover it.
 
 ## Why hono-problem-details?
 


### PR DESCRIPTION
## Summary
- Add weekly downloads, minzipped bundle size, and GitHub stars badges to the README header for stronger social proof
- Add a short star CTA under the tagline (above Install) to convert existing users into stargazers

## Test plan
- [x] Verify badges render on GitHub's rendered README
- [x] Confirm all badge links resolve to the correct destinations (npm, bundlephobia, stargazers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added npm download counts, bundle size, and GitHub stars badges to the README for improved project visibility.
  * Added a call-to-action encouraging users to star the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->