### PR TITLE
fix: raise hono peer-dep floor to >=4.12.14

### DIFF
--- a/.changeset/raise-hono-peer-floor.md
+++ b/.changeset/raise-hono-peer-floor.md
@@ -1,0 +1,9 @@
+---
+"hono-problem-details": patch
+---
+
+Raise `hono` peer-dependency floor from `>=4.0.0` to `>=4.12.14`.
+
+`hono@<4.12.14` is affected by an HTML-injection advisory in `hono/jsx` SSR (Dependabot alert #23, [GHSA](https://github.com/honojs/hono/security/advisories)). This library does not use `hono/jsx` and is not itself vulnerable, but the floor bump nudges consumers onto a patched `hono` so downstream apps that do use JSX SSR are not left on an unsafe version via transitive install resolution.
+
+Consumers pinned to `hono@<4.12.14` will see a peer-dep warning (pnpm/yarn) or resolution error (npm `--strict-peer-deps`). Upgrade `hono` to `^4.12.14` or later.

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
 		"@hono/zod-validator": "^0.7.6",
 		"@standard-schema/spec": "1.1.0",
 		"@vitest/coverage-v8": "^3.0.0",
-		"hono": "^4.7.0",
+		"hono": "^4.12.14",
 		"lefthook": "2.1.5",
 		"tsup": "^8.0.0",
 		"typescript": "^5.7.0",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
 		"@hono/zod-openapi": "^0.19.0",
 		"@hono/zod-validator": "^0.7.5",
 		"@standard-schema/spec": "^1.0.0",
-		"hono": ">=4.0.0",
+		"hono": ">=4.12.14",
 		"valibot": "^1.0.0",
 		"zod": "^3.25.0"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,16 +19,16 @@ importers:
         version: 2.30.0
       '@hono/standard-validator':
         specifier: 0.2.2
-        version: 0.2.2(@standard-schema/spec@1.1.0)(hono@4.12.12)
+        version: 0.2.2(@standard-schema/spec@1.1.0)(hono@4.12.14)
       '@hono/valibot-validator':
         specifier: ^0.6.1
-        version: 0.6.1(hono@4.12.12)(valibot@1.3.1(typescript@5.9.3))
+        version: 0.6.1(hono@4.12.14)(valibot@1.3.1(typescript@5.9.3))
       '@hono/zod-openapi':
         specifier: 0.19.10
-        version: 0.19.10(hono@4.12.12)(zod@3.25.76)
+        version: 0.19.10(hono@4.12.14)(zod@3.25.76)
       '@hono/zod-validator':
         specifier: ^0.7.6
-        version: 0.7.6(hono@4.12.12)(zod@3.25.76)
+        version: 0.7.6(hono@4.12.14)(zod@3.25.76)
       '@standard-schema/spec':
         specifier: 1.1.0
         version: 1.1.0
@@ -36,8 +36,8 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(vitest@3.2.4(yaml@2.8.2))
       hono:
-        specifier: ^4.7.0
-        version: 4.12.12
+        specifier: ^4.12.14
+        version: 4.12.14
       lefthook:
         specifier: 2.1.5
         version: 2.1.5
@@ -860,8 +860,8 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
-  hono@4.12.12:
-    resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
+  hono@4.12.14:
+    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@2.0.2:
@@ -1793,27 +1793,27 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
-  '@hono/standard-validator@0.2.2(@standard-schema/spec@1.1.0)(hono@4.12.12)':
+  '@hono/standard-validator@0.2.2(@standard-schema/spec@1.1.0)(hono@4.12.14)':
     dependencies:
       '@standard-schema/spec': 1.1.0
-      hono: 4.12.12
+      hono: 4.12.14
 
-  '@hono/valibot-validator@0.6.1(hono@4.12.12)(valibot@1.3.1(typescript@5.9.3))':
+  '@hono/valibot-validator@0.6.1(hono@4.12.14)(valibot@1.3.1(typescript@5.9.3))':
     dependencies:
-      hono: 4.12.12
+      hono: 4.12.14
       valibot: 1.3.1(typescript@5.9.3)
 
-  '@hono/zod-openapi@0.19.10(hono@4.12.12)(zod@3.25.76)':
+  '@hono/zod-openapi@0.19.10(hono@4.12.14)(zod@3.25.76)':
     dependencies:
       '@asteasolutions/zod-to-openapi': 7.3.4(zod@3.25.76)
-      '@hono/zod-validator': 0.7.6(hono@4.12.12)(zod@3.25.76)
-      hono: 4.12.12
+      '@hono/zod-validator': 0.7.6(hono@4.12.14)(zod@3.25.76)
+      hono: 4.12.14
       openapi3-ts: 4.5.0
       zod: 3.25.76
 
-  '@hono/zod-validator@0.7.6(hono@4.12.12)(zod@3.25.76)':
+  '@hono/zod-validator@0.7.6(hono@4.12.14)(zod@3.25.76)':
     dependencies:
-      hono: 4.12.12
+      hono: 4.12.14
       zod: 3.25.76
 
   '@inquirer/external-editor@1.0.3':
@@ -2264,7 +2264,7 @@ snapshots:
 
   has-flag@4.0.0: {}
 
-  hono@4.12.12: {}
+  hono@4.12.14: {}
 
   html-escaper@2.0.2: {}
 


### PR DESCRIPTION
## Summary

- Raises the `hono` peer-dependency floor from `>=4.0.0` to `>=4.12.14` to nudge consumers onto the patched hono version
- `hono@<4.12.14` is affected by a medium-severity HTML-injection advisory in `hono/jsx` SSR (Dependabot alert #23)
- This library does not use `hono/jsx` and is not itself vulnerable, but the floor bump prevents downstream apps that do use JSX SSR from resolving an unsafe hono transitively via this package
- Includes a patch changeset — will ship as `v0.2.1`

## Consumer impact

Consumers pinned to `hono@<4.12.14` will see a peer-dep warning (pnpm / yarn) or a resolution error (`npm --strict-peer-deps`). Upgrade `hono` to `^4.12.14` or later.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 189/189 passing
- [ ] Merge → verify Changesets bot opens "Version Packages" PR bumping to `0.2.1`
- [ ] Merge Version Packages PR → verify `pnpm release` publishes `0.2.1` to npm with provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)