### PR TITLE
feat(handler): add autoInstance option and widen localize return type

### DIFF
--- a/.changeset/handler-dx-autoinstance-localize.md
+++ b/.changeset/handler-dx-autoinstance-localize.md
@@ -7,8 +7,8 @@ Add `autoInstance` handler option and widen `localize` return type to accept par
 - **`problemDetailsHandler({ autoInstance: true })`** populates `instance` from `c.req.path`
   when the thrown problem did not specify one. Opt-in to avoid silently changing response
   shape for existing consumers; explicit `instance` values always win.
-- **`localize` callback** may now return `Partial<ProblemDetails> | void` instead of the
-  full object. This aligns the TypeScript type with the existing runtime behaviour
+- **`localize` callback** may now return `Partial<ProblemDetails> | undefined` instead of
+  the full object. This aligns the TypeScript type with the existing runtime behaviour
   (`{ ...pd, ...localize(pd, c) }`). Returning the full object still works; existing
   callbacks compile unchanged.
 - README: documents the `title`-from-status auto-fill (unchanged runtime behaviour) and the

--- a/.changeset/handler-dx-autoinstance-localize.md
+++ b/.changeset/handler-dx-autoinstance-localize.md
@@ -1,0 +1,16 @@
+---
+"hono-problem-details": minor
+---
+
+Add `autoInstance` handler option and widen `localize` return type to accept partial patches.
+
+- **`problemDetailsHandler({ autoInstance: true })`** populates `instance` from `c.req.path`
+  when the thrown problem did not specify one. Opt-in to avoid silently changing response
+  shape for existing consumers; explicit `instance` values always win.
+- **`localize` callback** may now return `Partial<ProblemDetails> | void` instead of the
+  full object. This aligns the TypeScript type with the existing runtime behaviour
+  (`{ ...pd, ...localize(pd, c) }`). Returning the full object still works; existing
+  callbacks compile unchanged.
+- README: documents the `title`-from-status auto-fill (unchanged runtime behaviour) and the
+  new `autoInstance` shortcut so callers stop hand-writing `title`/`instance` for stock
+  HTTP semantics.

--- a/README.md
+++ b/README.md
@@ -125,6 +125,11 @@ throw problemDetails({
 `instance` points at the specific occurrence — clients can use it as a key for retry logic
 or deduplication.
 
+> **Auto-fill shortcuts.** `title` is optional — when omitted, the standard HTTP reason phrase
+> for `status` is used (`404` → `"Not Found"`). Similarly, `instance` can be populated from
+> the request path automatically via `problemDetailsHandler({ autoInstance: true })`. Both
+> shortcuts skip the boilerplate in the example above; explicit values always win.
+
 ### Conflict — 409
 
 ```ts
@@ -337,14 +342,16 @@ const errorWithExtensions = createProblemDetailsSchema(
 
 ## Localization
 
-Use the `localize` callback to translate `title` and `detail` based on the request context:
+Use the `localize` callback to translate `title` and `detail` based on the request context.
+Return a partial patch with just the fields you want to override — everything else falls
+through unchanged. Returning nothing (or `undefined`) leaves the response untouched.
 
 ```ts
 problemDetailsHandler({
   localize: (pd, c) => {
     const lang = c.req.header("Accept-Language");
     if (lang?.startsWith("ja")) {
-      return { ...pd, title: translate("ja", pd.title) };
+      return { title: translate("ja", pd.title) };
     }
     return pd;
   },
@@ -376,8 +383,12 @@ problemDetailsHandler({
   // Include stack trace in detail (for development)
   includeStack: process.env.NODE_ENV === "development",
 
-  // Localize title/detail before sending the response
-  localize: (pd, c) => ({ ...pd, title: `[${lang}] ${pd.title}` }),
+  // Populate `instance` from `c.req.path` when the thrown problem didn't specify one
+  autoInstance: true,
+
+  // Localize title/detail before sending the response.
+  // Return a partial patch — fields you omit fall through from the original.
+  localize: (pd, c) => ({ title: `[${lang}] ${pd.title}` }),
 
   // Custom error mapping
   mapError: (error) => {

--- a/README.md
+++ b/README.md
@@ -388,7 +388,10 @@ problemDetailsHandler({
 
   // Localize title/detail before sending the response.
   // Return a partial patch — fields you omit fall through from the original.
-  localize: (pd, c) => ({ title: `[${lang}] ${pd.title}` }),
+  localize: (pd, c) => {
+    const lang = c.req.header("Accept-Language") ?? "en";
+    return { title: `[${lang}] ${pd.title}` };
+  },
 
   // Custom error mapping
   mapError: (error) => {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -20,6 +20,10 @@ function toResponse(
 ): Response {
 	let pd = normalizeProblemDetails(input);
 
+	if (options.autoInstance && pd.instance === undefined) {
+		pd = { ...pd, instance: c.req.path };
+	}
+
 	if (options.localize) {
 		try {
 			pd = { ...pd, ...options.localize(pd, c) };

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,8 +42,18 @@ export interface ProblemDetailsHandlerOptions {
 	defaultType?: string;
 	/** Include stack trace in detail (for development) */
 	includeStack?: boolean;
+	/**
+	 * When `true`, populate `instance` from the request path (`c.req.path`) if
+	 * the thrown problem didn't specify one. Explicit values always win.
+	 * Default: `false` — opt-in to avoid silently changing response shape.
+	 */
+	autoInstance?: boolean;
 	/** Custom error to ProblemDetails mapping */
 	mapError?: (error: Error) => ProblemDetailsInput | undefined;
-	/** Localize title/detail before sending the response */
-	localize?: (pd: ProblemDetails, c: Context) => ProblemDetails;
+	/**
+	 * Localize title/detail before sending the response.
+	 * Returned fields are merged onto the original ProblemDetails, so callers may
+	 * return a partial patch (e.g. `{ title: "..." }`) or omit the return entirely.
+	 */
+	localize?: (pd: ProblemDetails, c: Context) => Partial<ProblemDetails> | undefined;
 }

--- a/tests/handler.test.ts
+++ b/tests/handler.test.ts
@@ -474,7 +474,7 @@ describe("problemDetailsHandler", () => {
 
 	it("H32: localize returning partial fields preserves other fields", async () => {
 		const app = createApp({
-			localize: () => ({ title: "Localized Title" }) as never,
+			localize: () => ({ title: "Localized Title" }),
 		});
 		app.get("/", () => {
 			throw new HTTPException(404, { message: "Not found" });
@@ -571,5 +571,73 @@ describe("problemDetailsHandler", () => {
 		expect(res.status).toBe(400);
 		const body = await res.json();
 		expect(body.title).toBe("Localized");
+	});
+
+	it("H38: autoInstance populates instance from request path for ProblemDetailsError", async () => {
+		const app = createApp({ autoInstance: true });
+		app.get("/orders/:id", (c) => {
+			throw problemDetails({ status: 404, title: "Not Found" });
+		});
+		const res = await app.request("/orders/123");
+		const body = await res.json();
+		expect(body.instance).toBe("/orders/123");
+	});
+
+	it("H39: autoInstance populates instance for HTTPException", async () => {
+		const app = createApp({ autoInstance: true });
+		app.get("/users/:id", () => {
+			throw new HTTPException(403, { message: "Forbidden" });
+		});
+		const res = await app.request("/users/42");
+		const body = await res.json();
+		expect(body.instance).toBe("/users/42");
+	});
+
+	it("H40: autoInstance populates instance for unhandled Error", async () => {
+		const app = createApp({ autoInstance: true });
+		app.get("/crash", () => {
+			throw new Error("boom");
+		});
+		const res = await app.request("/crash");
+		const body = await res.json();
+		expect(body.instance).toBe("/crash");
+	});
+
+	it("H41: autoInstance does not overwrite explicit instance", async () => {
+		const app = createApp({ autoInstance: true });
+		app.get("/orders/:id", () => {
+			throw problemDetails({
+				status: 404,
+				title: "Not Found",
+				instance: "urn:order:123",
+			});
+		});
+		const res = await app.request("/orders/123");
+		const body = await res.json();
+		expect(body.instance).toBe("urn:order:123");
+	});
+
+	it("H42: autoInstance default is off (no instance populated)", async () => {
+		const app = createApp();
+		app.get("/orders/:id", () => {
+			throw problemDetails({ status: 404, title: "Not Found" });
+		});
+		const res = await app.request("/orders/123");
+		const body = await res.json();
+		expect(body.instance).toBeUndefined();
+	});
+
+	it("H43: autoInstance populated value is visible to localize callback", async () => {
+		const app = createApp({
+			autoInstance: true,
+			localize: (pd) => ({ detail: `at ${pd.instance}` }),
+		});
+		app.get("/orders/:id", () => {
+			throw problemDetails({ status: 404, title: "Not Found" });
+		});
+		const res = await app.request("/orders/7");
+		const body = await res.json();
+		expect(body.detail).toBe("at /orders/7");
+		expect(body.instance).toBe("/orders/7");
 	});
 });


### PR DESCRIPTION
## Summary

- **`autoInstance` handler option** (opt-in): when set, `problemDetailsHandler` populates `instance` from `c.req.path` if the thrown problem didn't specify one. Explicit `instance` values always win.
- **`localize` return type widened to `Partial<ProblemDetails> | undefined`**: aligns the TypeScript type with the existing `{ ...pd, ...localize(pd, c) }` runtime merge. Existing callbacks that return the full object keep compiling.
- **README**: documents the `title` fallback from HTTP status phrase (pre-existing runtime behaviour — no code change) and the new `autoInstance` shortcut.

Motivation: user feedback flagged that `c.req.path` and the standard HTTP reason phrase are almost always what callers want, but had to be hand-written every time. Both shortcuts remove boilerplate without changing response semantics.

## Test plan

- [x] `pnpm test` — 195/195 pass (6 new handler tests H38–H43)
- [x] `pnpm exec vitest run --coverage` — 100% statements / branch / functions / lines
- [x] `pnpm typecheck` — clean
- [x] `pnpm biome check` on feature files — clean (pre-commit lefthook hook passed)

### Covered cases
- H38 / H39 / H40 — `autoInstance` populates for `ProblemDetailsError`, `HTTPException`, and unhandled `Error`
- H41 — explicit `instance` not overwritten
- H42 — default off (opt-in)
- H43 — populated `instance` visible to `localize` (ordering contract)
- H32 — partial return from `localize` compiles without `as never` cast

## Breaking changes

None. `autoInstance` defaults to `false`; `localize` return-type widening accepts a strict superset of what was previously valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `autoInstance` handler option to automatically populate the instance field from the request path when not explicitly provided.

* **Documentation**
  * Updated guides explaining auto-fill behavior for title and instance fields in problem details responses.
  * Clarified that localization callbacks should return partial patches containing only fields to override.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->