### PR TITLE
chore: gitignore Claude Code session-local settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage/
 .DS_Store
 .npmrc
 .envrc
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

Adds `.claude/settings.local.json` to `.gitignore`. The file is written by Claude Code during a session as permission grants accumulate, and its tab/space formatting does not match this project's biome rules, causing `pnpm lint` to fail locally on developer machines.

Biome inherits `.gitignore` via `vcs.useIgnoreFile: true` (see `biome.json`), so no biome config change is needed. CI is unaffected — the file never existed there.

## Test plan

- [x] `pnpm lint` — clean (31 files checked, down from 32; no errors)
- [x] File is untracked and stays that way after future Claude Code sessions

No release needed (no user-facing behaviour change, so no changeset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)