### PR TITLE
feat(openapi)!: support Zod v4 and bump @hono/zod-openapi to v1

### DIFF
--- a/.changeset/support-zod-v4.md
+++ b/.changeset/support-zod-v4.md
@@ -1,0 +1,11 @@
+---
+"hono-problem-details": minor
+---
+
+Support Zod v4 and bump `@hono/zod-openapi` to v1
+
+- `zod` peer dependency range widened from `^3.25.0` to `^3.25.0 || ^4.0.0`. The `./zod` integration works unchanged because it only touches `ZodError.issues` and `issue.path/message/code`, which are compatible across v3 and v4.
+- `@hono/zod-openapi` peer dependency bumped from `^0.19.0` to `^1.0.0`. Consumers using `./openapi` must upgrade to `@hono/zod-openapi@^1` (which requires `zod@^4`).
+- `./openapi` internal rewrite: `.merge()` → `.extend()` and `z.AnyZodObject` → `z.ZodObject` to match Zod v4 API. `createProblemDetailsSchema` now returns `z.ZodObject` (previously `z.AnyZodObject`). `problemDetailsResponse` now accepts `z.ZodType` (previously `z.ZodTypeAny`).
+
+CI is now exercised against Zod v4 and `@hono/zod-openapi` v1 at dev-dependency level, so v4 compatibility is verified end-to-end rather than only declared.

--- a/package.json
+++ b/package.json
@@ -103,12 +103,12 @@
 	"peerDependencies": {
 		"@hono/standard-validator": "^0.2.0",
 		"@hono/valibot-validator": "^0.6.0",
-		"@hono/zod-openapi": "^0.19.0",
+		"@hono/zod-openapi": "^1.0.0",
 		"@hono/zod-validator": "^0.7.5",
 		"@standard-schema/spec": "^1.0.0",
 		"hono": ">=4.12.14",
 		"valibot": "^1.0.0",
-		"zod": "^3.25.0"
+		"zod": "^3.25.0 || ^4.0.0"
 	},
 	"peerDependenciesMeta": {
 		"@hono/zod-validator": {
@@ -139,7 +139,7 @@
 		"@changesets/cli": "2.30.0",
 		"@hono/standard-validator": "0.2.2",
 		"@hono/valibot-validator": "^0.6.1",
-		"@hono/zod-openapi": "0.19.10",
+		"@hono/zod-openapi": "1.3.0",
 		"@hono/zod-validator": "^0.7.6",
 		"@standard-schema/spec": "1.1.0",
 		"@vitest/coverage-v8": "^3.0.0",
@@ -147,9 +147,9 @@
 		"lefthook": "2.1.5",
 		"tsup": "^8.0.0",
 		"typescript": "^5.7.0",
-		"valibot": "^1.0.0",
+		"valibot": "^1.3.1",
 		"vitest": "^3.0.0",
-		"zod": "^3.25.0"
+		"zod": "^4.0.0"
 	},
 	"engines": {
 		"node": ">=20"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,11 +24,11 @@ importers:
         specifier: ^0.6.1
         version: 0.6.1(hono@4.12.14)(valibot@1.3.1(typescript@5.9.3))
       '@hono/zod-openapi':
-        specifier: 0.19.10
-        version: 0.19.10(hono@4.12.14)(zod@3.25.76)
+        specifier: 1.3.0
+        version: 1.3.0(hono@4.12.14)(zod@4.3.6)
       '@hono/zod-validator':
         specifier: ^0.7.6
-        version: 0.7.6(hono@4.12.14)(zod@3.25.76)
+        version: 0.7.6(hono@4.12.14)(zod@4.3.6)
       '@standard-schema/spec':
         specifier: 1.1.0
         version: 1.1.0
@@ -48,14 +48,14 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
       valibot:
-        specifier: ^1.0.0
+        specifier: ^1.3.1
         version: 1.3.1(typescript@5.9.3)
       vitest:
         specifier: ^3.0.0
         version: 3.2.4(yaml@2.8.2)
       zod:
-        specifier: ^3.25.0
-        version: 3.25.76
+        specifier: ^4.0.0
+        version: 4.3.6
 
 packages:
 
@@ -63,10 +63,10 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@asteasolutions/zod-to-openapi@7.3.4':
-    resolution: {integrity: sha512-/2rThQ5zPi9OzVwes6U7lK1+Yvug0iXu25olp7S0XsYmOqnyMfxH7gdSQjn/+DSOHRg7wnotwGJSyL+fBKdnEA==}
+  '@asteasolutions/zod-to-openapi@8.5.0':
+    resolution: {integrity: sha512-SABbKiObg5dLRiTFnqiW1WWwGcg1BJfmHtT2asIBnBHg6Smy/Ms2KHc650+JI4Hw7lSkdiNebEGXpwoxfben8Q==}
     peerDependencies:
-      zod: ^3.20.2
+      zod: ^4.0.0
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
@@ -375,12 +375,12 @@ packages:
       hono: '>=3.9.0'
       valibot: ^1.0.0 || ^1.0.0-beta.4 || ^1.0.0-rc
 
-  '@hono/zod-openapi@0.19.10':
-    resolution: {integrity: sha512-dpoS6DenvoJyvxtQ7Kd633FRZ/Qf74+4+o9s+zZI8pEqnbjdF/DtxIib08WDpCaWabMEJOL5TXpMgNEZvb7hpA==}
+  '@hono/zod-openapi@1.3.0':
+    resolution: {integrity: sha512-loDVevfMaaNa0slskhpMcqjSdidVXba2QJwNVmnS5Dp6L8AqSgtjJxWGJfRZtosyzYOb5gx4ZzXNCe+QhwY7xw==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       hono: '>=4.3.6'
-      zod: '>=3.0.0'
+      zod: ^4.0.0
 
   '@hono/zod-validator@0.7.6':
     resolution: {integrity: sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw==}
@@ -1490,8 +1490,8 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
 
@@ -1500,10 +1500,10 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@asteasolutions/zod-to-openapi@7.3.4(zod@3.25.76)':
+  '@asteasolutions/zod-to-openapi@8.5.0(zod@4.3.6)':
     dependencies:
       openapi3-ts: 4.5.0
-      zod: 3.25.76
+      zod: 4.3.6
 
   '@babel/helper-string-parser@7.27.1': {}
 
@@ -1803,18 +1803,18 @@ snapshots:
       hono: 4.12.14
       valibot: 1.3.1(typescript@5.9.3)
 
-  '@hono/zod-openapi@0.19.10(hono@4.12.14)(zod@3.25.76)':
+  '@hono/zod-openapi@1.3.0(hono@4.12.14)(zod@4.3.6)':
     dependencies:
-      '@asteasolutions/zod-to-openapi': 7.3.4(zod@3.25.76)
-      '@hono/zod-validator': 0.7.6(hono@4.12.14)(zod@3.25.76)
+      '@asteasolutions/zod-to-openapi': 8.5.0(zod@4.3.6)
+      '@hono/zod-validator': 0.7.6(hono@4.12.14)(zod@4.3.6)
       hono: 4.12.14
       openapi3-ts: 4.5.0
-      zod: 3.25.76
+      zod: 4.3.6
 
-  '@hono/zod-validator@0.7.6(hono@4.12.14)(zod@3.25.76)':
+  '@hono/zod-validator@0.7.6(hono@4.12.14)(zod@4.3.6)':
     dependencies:
       hono: 4.12.14
-      zod: 3.25.76
+      zod: 4.3.6
 
   '@inquirer/external-editor@1.0.3':
     dependencies:
@@ -2833,4 +2833,4 @@ snapshots:
 
   yaml@2.8.2: {}
 
-  zod@3.25.76: {}
+  zod@4.3.6: {}

--- a/src/integrations/openapi.ts
+++ b/src/integrations/openapi.ts
@@ -29,8 +29,8 @@ export const ProblemDetailsSchema: z.ZodObject<{
  */
 export function createProblemDetailsSchema<T extends z.ZodRawShape>(
 	extensions: z.ZodObject<T>,
-): z.AnyZodObject {
-	return ProblemDetailsSchema.merge(extensions).openapi({ title: "ProblemDetails" });
+): z.ZodObject {
+	return ProblemDetailsSchema.extend(extensions.shape).openapi({ title: "ProblemDetails" });
 }
 
 /**
@@ -40,9 +40,9 @@ export function createProblemDetailsSchema<T extends z.ZodRawShape>(
 export function problemDetailsResponse(
 	status: number,
 	description?: string,
-	schema: z.ZodTypeAny = ProblemDetailsSchema,
+	schema: z.ZodType = ProblemDetailsSchema,
 ): {
-	content: { "application/problem+json": { schema: z.ZodTypeAny } };
+	content: { "application/problem+json": { schema: z.ZodType } };
 	description: string;
 } {
 	return {

--- a/tests/integrations/openapi.test.ts
+++ b/tests/integrations/openapi.test.ts
@@ -47,10 +47,28 @@ describe("ProblemDetailsSchema", () => {
 		}
 	});
 
-	it("O5: has OpenAPI metadata", () => {
-		const metadata = ProblemDetailsSchema._def.openapi?.metadata;
-		expect(metadata).toBeDefined();
-		expect(metadata?.title).toBe("ProblemDetails");
+	it("O5: emits 'ProblemDetails' title in generated OpenAPI schema", () => {
+		const app = new OpenAPIHono();
+		app.openapi(
+			createRoute({
+				method: "get",
+				path: "/err",
+				responses: { 400: problemDetailsResponse(400) },
+			}),
+			// biome-ignore lint/suspicious/noExplicitAny: required by OpenAPIHono typing
+			(c) => c.json({} as any, 400),
+		);
+		const doc = app.getOpenAPI31Document({
+			openapi: "3.1.0",
+			info: { title: "Test", version: "1.0.0" },
+		});
+		const schema = (
+			(doc.paths?.["/err"]?.get?.responses?.["400"] as Record<string, unknown>)?.content as Record<
+				string,
+				{ schema: Record<string, unknown> }
+			>
+		)?.["application/problem+json"]?.schema;
+		expect(schema?.title).toBe("ProblemDetails");
 	});
 });
 
@@ -95,16 +113,31 @@ describe("createProblemDetailsSchema", () => {
 		}
 	});
 
-	it("O8: extension schema preserves OpenAPI metadata", () => {
-		const schema = createProblemDetailsSchema(
+	it("O8: extension schema preserves 'ProblemDetails' title in generated doc", () => {
+		const customSchema = createProblemDetailsSchema(
 			z.object({
 				retryAfter: z.number(),
 			}),
 		);
-
-		const metadata = schema._def.openapi?.metadata;
-		expect(metadata).toBeDefined();
-		expect(metadata?.title).toBe("ProblemDetails");
+		const app = new OpenAPIHono();
+		app.openapi(
+			createRoute({
+				method: "get",
+				path: "/retry",
+				responses: { 429: problemDetailsResponse(429, undefined, customSchema) },
+			}),
+			// biome-ignore lint/suspicious/noExplicitAny: required by OpenAPIHono typing
+			(c) => c.json({} as any, 429),
+		);
+		const doc = app.getOpenAPI31Document({
+			openapi: "3.1.0",
+			info: { title: "Test", version: "1.0.0" },
+		});
+		const schema = (
+			(doc.paths?.["/retry"]?.get?.responses?.["429"] as Record<string, unknown>)
+				?.content as Record<string, { schema: Record<string, unknown> }>
+		)?.["application/problem+json"]?.schema;
+		expect(schema?.title).toBe("ProblemDetails");
 	});
 });
 


### PR DESCRIPTION
## Summary
- Widens `zod` peer to `^3.25.0 || ^4.0.0`. The `./zod` integration works unchanged — it only touches `ZodError.issues` and `issue.path/message/code`, which are compatible across v3 and v4.
- **Breaking for `./openapi` consumers**: bumps `@hono/zod-openapi` peer to `^1.0.0` (which requires `zod@^4`). Users of the openapi integration must upgrade both together.
- Rewrites `src/integrations/openapi.ts` for the Zod v4 API:
  - `ProblemDetailsSchema.merge(extensions)` → `ProblemDetailsSchema.extend(extensions.shape)`
  - `createProblemDetailsSchema` return type: `z.AnyZodObject` → `z.ZodObject`
  - `problemDetailsResponse` schema param: `z.ZodTypeAny` → `z.ZodType`
- Rewrites O5/O8 tests from internal-metadata reads to generated-doc behavior checks. In `@asteasolutions/zod-to-openapi` v8 (bundled with `@hono/zod-openapi` v1), openapi metadata lives in the library's own registry, not on `_def.openapi`.
- Bumps devDeps to validate v4 end-to-end in CI, not just declare it via peer range: `zod@^4.0.0`, `@hono/zod-openapi@1.3.0`, `valibot@^1.3.1`.

Published as a `minor` bump via changeset. Pre-1.0 conventions allow breaking changes under minor; the changeset explicitly documents the openapi peer bump.

## Test plan
- [x] `pnpm test` — 195/195 pass
- [x] `pnpm vitest run --coverage` — 100% coverage preserved across all files
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — ESM + CJS dual output succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Zod v4 while maintaining compatibility with Zod v3.25.0+.

* **Dependencies**
  * Updated peer dependency requirements: @hono/zod-openapi now requires v1.0.0 or higher for full Zod v4 compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->