### PR TITLE
docs: add 500 response section and OpenAPI peer-dep note

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,49 @@ throw problemDetails({
 Rate-limit metadata goes in `extensions` — clients read it straight from the body instead
 of juggling `Retry-After` headers.
 
+## Unhandled Errors — 500
+
+Anything thrown that isn't a `ProblemDetailsError` or `HTTPException` (and isn't matched by
+`mapError`) becomes a generic 500. `detail` is **always** the constant string
+`"An unexpected error occurred"` — never the raw `error.message` or stack — so UIs that
+render `detail` verbatim cannot leak server internals.
+
+```ts
+app.get("/boom", () => {
+  throw new Error("DB connection lost: ECONNREFUSED");
+});
+
+// HTTP/1.1 500 Internal Server Error
+// Content-Type: application/problem+json
+// {
+//   "type": "about:blank",
+//   "status": 500,
+//   "title": "Internal Server Error",
+//   "detail": "An unexpected error occurred"
+// }
+```
+
+In development, set `includeStack: true` to surface the stack trace as a top-level `stack`
+extension member. `detail` stays constant either way — read the stack from `body.stack`:
+
+```ts
+problemDetailsHandler({
+  includeStack: process.env.NODE_ENV !== "production",
+});
+
+// HTTP/1.1 500 Internal Server Error
+// {
+//   "type": "about:blank",
+//   "status": 500,
+//   "title": "Internal Server Error",
+//   "detail": "An unexpected error occurred",
+//   "stack": "Error: DB connection lost: ECONNREFUSED\n    at ..."
+// }
+```
+
+Keep `includeStack` off in production — stack traces should not leave the server even via
+opt-in extension fields.
+
 ## Extension Members
 
 Extension members are flattened to top level per RFC 9457:
@@ -295,6 +338,11 @@ app.post("/users", sValidator("json", schema, standardSchemaProblemHook()), (c) 
 ```
 
 ## OpenAPI Integration
+
+> **Peer dependencies**: `./openapi` requires `@hono/zod-openapi@^1.0.0`, which in turn
+> requires `zod@^4.0.0`. The base `./zod` integration (validator hook) works with both
+> `zod@^3.25.0` and `zod@^4.0.0` — the version constraint above only applies when you import
+> from `hono-problem-details/openapi`.
 
 Use with `@hono/zod-openapi` to document Problem Details error responses in your OpenAPI spec:
 


### PR DESCRIPTION
## Summary
- Adds an **Unhandled Errors — 500** section documenting the v0.4.0 contract: `detail` is always the constant `"An unexpected error occurred"`, and `includeStack: true` emits the stack as `extensions.stack` (read via `body.stack`). Previously this behaviour was only described in CHANGELOG / handler option comments, with no response example in README.
- Adds a peer-dependency note to the **OpenAPI Integration** section. After v0.5.0 (#113), `./openapi` requires `@hono/zod-openapi@^1.0.0` (which requires `zod@^4.0.0`), while the base `./zod` integration remains compatible with both `zod@^3.25.0` and `zod@^4.0.0`. The asymmetric peer-dep matrix wasn't visible to README-only readers.

Docs-only change. +48 / -0 lines, no source or test changes.

## Test plan
- [x] `pnpm lint` passes
- [ ] Render README on GitHub and verify both new sections look correct
- [ ] Sanity-check that the peer-dep note is unambiguous to a reader who only uses `./zod`

🤖 Generated with [Claude Code](https://claude.com/claude-code)