### PR TITLE
ci(release): switch to npm Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,9 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha }}
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
-          node-version: 22
+          # Node 24 ships with npm 11.x (required for OIDC Trusted Publishing).
+          # Node 22 ships with npm 10.x and self-upgrading via 'npm install -g npm@latest' is unreliable in CI.
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
       - name: Enable corepack
         run: corepack enable
@@ -54,8 +56,6 @@ jobs:
           version: pnpm version-packages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Set ci-pass status on Version Packages PR
         if: steps.changesets.outputs.pullRequestNumber
         env:


### PR DESCRIPTION
## Summary

Migrate `release.yml` from token-based npm publishing to OIDC **Trusted Publishing**.

- Remove `NPM_TOKEN` / `NODE_AUTH_TOKEN` env vars from the changesets/action step
- Bump runner Node version to 24 (ships with npm 11.x, required for OIDC publish; Node 22 ships with npm 10.x)

The existing `workflow_run` trigger, defense-in-depth `if` condition, and SHA-pinned actions are preserved as-is.

## Precondition — DO NOT MERGE until configured

Before merging this PR, configure a Trusted Publisher entry on npmjs.com:

1. Go to https://www.npmjs.com/package/hono-problem-details/access
2. Settings → Trusted Publisher → Add GitHub Actions
3. Fill in:
   - Organization or user: `paveg`
   - Repository: `hono-problem-details`
   - Workflow filename: `release.yml`
   - Environment name: (leave empty)

If this PR is merged before the Trusted Publisher is configured, the next npm publish will fail with `E401` (no auth).

## Why

Once configured, the runner exchanges its GitHub OIDC token for a short-lived npm publish token at the registry. No long-lived secret is involved. After this PR ships and the next release publishes successfully via OIDC, the package's "Publishing access" can be tightened to "disallow tokens" and the `NPM_TOKEN` repository secret can be removed.

## Test plan

- [ ] Trusted Publisher configured on npmjs.com (see precondition above)
- [ ] CI passes
- [ ] Next publish run uses OIDC and attaches provenance
- [ ] No `EOTP` / `E401` errors in the publish step

🤖 Generated with [Claude Code](https://claude.com/claude-code)
