### PR TITLE
ci: add TypeScript compat matrix (5.0/5.4/5.7/5.9)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,40 @@ jobs:
       - run: pnpm vitest run --coverage
       - run: pnpm build
 
-  ci-pass:
+  type-compat:
     runs-on: ubuntu-latest
     needs: ci
+    strategy:
+      fail-fast: false
+      matrix:
+        ts: ["5.0.4", "5.4.5", "5.7.3", "5.9.3"]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: 22
+      - name: Enable corepack
+        run: corepack enable
+      - name: Resolve pnpm store path
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_ENV"
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - name: Type-check consumer against TS ${{ matrix.ts }}
+        env:
+          TS_VERSION: ${{ matrix.ts }}
+        run: pnpm dlx --package="typescript@${TS_VERSION}" -c 'tsc -p tsconfig.compat.json'
+
+  ci-pass:
+    runs-on: ubuntu-latest
+    needs: [ci, type-compat]
     if: always()
     steps:
       - run: exit 1
-        if: needs.ci.result == 'failure' || needs.ci.result == 'cancelled'
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ can all agree on.
 npm install hono-problem-details
 ```
 
+### Requirements
+
+- Hono `>= 4.12.14` (peer dependency)
+- TypeScript `>= 5.0` — the published `.d.ts` files are CI-tested against TS 5.0, 5.4, 5.7, and 5.9. Older TS versions may work but are not verified.
+- Node.js `>= 20`
+
 ## Quick Start
 
 ```ts

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
 		"lint:fix": "biome check --write .",
 		"format": "biome format --write .",
 		"typecheck": "tsc --noEmit",
+		"test:compat": "tsc -p tsconfig.compat.json",
 		"release": "pnpm build && changeset publish",
 		"version-packages": "changeset version && pnpm lint:fix"
 	},

--- a/tests/type-compat/core-consumer.ts
+++ b/tests/type-compat/core-consumer.ts
@@ -1,0 +1,69 @@
+import type {
+	ProblemDetails,
+	ProblemDetailsHandlerOptions,
+	ProblemDetailsInput,
+} from "../../dist/index.js";
+import {
+	createProblemTypeRegistry,
+	PROBLEM_JSON_CONTENT_TYPE,
+	ProblemDetailsError,
+	problemDetails,
+	problemDetailsHandler,
+	statusToPhrase,
+	statusToSlug,
+} from "../../dist/index.js";
+
+const _ct: typeof PROBLEM_JSON_CONTENT_TYPE = PROBLEM_JSON_CONTENT_TYPE;
+
+const _problem: ProblemDetails = {
+	type: "https://example.com/problems/forbidden",
+	title: "Forbidden",
+	status: 403,
+	detail: "You don't have permission",
+	instance: "/orders/42",
+};
+
+const _input: ProblemDetailsInput = {
+	status: 400,
+	title: "Bad Request",
+};
+
+const _opts: ProblemDetailsHandlerOptions = {
+	autoInstance: true,
+	includeStack: false,
+};
+
+const _err: ProblemDetailsError = new ProblemDetailsError({
+	status: 404,
+	title: "Not Found",
+});
+
+const _factoryResult = problemDetails({ status: 500, title: "Server Error" });
+
+const _handler = problemDetailsHandler();
+
+const _registry = createProblemTypeRegistry({
+	ORDER_CONFLICT: {
+		type: "https://example.com/problems/order-conflict",
+		status: 409,
+		title: "Order Conflict",
+	},
+});
+const _registryError: ProblemDetailsError = _registry.create("ORDER_CONFLICT", {
+	detail: "Already exists",
+});
+
+const _phrase: string | undefined = statusToPhrase(404);
+const _slug: string | undefined = statusToSlug(404);
+
+void _ct;
+void _problem;
+void _input;
+void _opts;
+void _err;
+void _factoryResult;
+void _handler;
+void _registry;
+void _registryError;
+void _phrase;
+void _slug;

--- a/tsconfig.compat.json
+++ b/tsconfig.compat.json
@@ -1,0 +1,15 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"lib": ["ES2022"],
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"isolatedModules": true,
+		"noEmit": true,
+		"types": []
+	},
+	"include": ["tests/type-compat/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Phase 1 of the TypeScript supported-range strategy. Establishes the baseline floor at **TS 5.0+** as a tested, machine-verified invariant rather than a docs-only claim.

This is a prerequisite for safely bumping the dev `typescript` to 6.x later — without this matrix, a stricter d.ts syntax leaking into the build would break TS 5 consumers silently.

### What this guards against

The library is built with a pinned dev TypeScript (currently 5.9), but consumers may compile against older TS. If a future build emits `.d.ts` syntax requiring a newer TS than declared, library users on the older TS would see compile errors with no warning at PR time. The matrix detects this at PR time.

### How it works

```mermaid
flowchart LR
  A[ci job<br/>build dist/] --> B[type-compat matrix]
  B --> M1[TS 5.0.4<br/>tsc consumer]
  B --> M2[TS 5.4.5<br/>tsc consumer]
  B --> M3[TS 5.7.3<br/>tsc consumer]
  B --> M4[TS 5.9.3<br/>tsc consumer]
  M1 & M2 & M3 & M4 --> P[ci-pass]
```

- `tests/type-compat/core-consumer.ts` exercises the full public API surface, importing from `dist/` (the post-build artifacts users actually receive).
- `tsconfig.compat.json` type-checks `consumer.ts` in isolation with ES2022 + bundler resolution + strict — the typical consumer config.
- New CI job `type-compat` runs after `ci` (which builds `dist/`) and re-checks `consumer.ts` with each matrix TS version via `pnpm dlx --package=typescript@${TS_VERSION}`.
- `ci-pass` now requires **both** `ci` and `type-compat` to succeed.

### Scope

Core API only for this phase. Integrations (`zod`/`valibot`/`openapi`/`standard-schema`) inherit their TS floor from peer-dep packages, so testing them here would mostly measure peer-dep compatibility rather than ours. They can be added later if needed.

### Documentation

README updated with explicit `TypeScript >= 5.0` requirement under a new `Requirements` subsection.

## Test plan

- [x] `pnpm build` — clean
- [x] `pnpm test:compat` — clean with current TS 5.9
- [x] `pnpm dlx --package=typescript@5.0.4 -c 'tsc -p tsconfig.compat.json'` — clean (TS 5.0.4 verified locally)
- [x] `pnpm lint` / `pnpm typecheck` / `pnpm test` — all green
- [x] CI workflow YAML uses env-var passing for matrix values (defense-in-depth against injection patterns, even though matrix values are controlled)

## Follow-up (Phase 2, separate PR)

Bump dev `typescript` to 6.x with `ignoreDeprecations: "6.0"` in `tsconfig.json` (workaround for `tsup#1388`), and add `6.0.x` to this matrix. With Phase 1 in place, that bump is verifiable rather than a leap of faith.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
