### PR TITLE
chore: drop Node.js 20 support (EOL April 2026)

### DIFF
--- a/.changeset/drop-node-20.md
+++ b/.changeset/drop-node-20.md
@@ -1,0 +1,9 @@
+---
+"hono-problem-details": minor
+---
+
+Drop Node.js 20 support; minimum is now Node 22.
+
+Node 20 reached end-of-life in April 2026 (https://nodejs.org/en/about/previous-releases). The `engines.node` floor has been raised to `>=22`, and the CI matrix now tests against Node 22 and 24 only.
+
+If you are still on Node 20, pin `hono-problem-details` to `<0.6.0` until you can upgrade. The runtime API is unchanged.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [22, 24]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ npm install hono-problem-details
 
 - Hono `>= 4.12.14` (peer dependency)
 - TypeScript `>= 5.0` — the published `.d.ts` files are CI-tested against TS 5.0, 5.4, 5.7, and 5.9. Older TS versions may work but are not verified.
-- Node.js `>= 20`
+- Node.js `>= 22` (Node 20 reached end-of-life in April 2026; v0.6.0 raised the floor)
 
 ## Quick Start
 

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
 		"zod": "^4.0.0"
 	},
 	"engines": {
-		"node": ">=20"
+		"node": ">=22"
 	},
 	"packageManager": "pnpm@10.14.0",
 	"pnpm": {


### PR DESCRIPTION
## Summary

Node.js 20 reached end-of-life on **2026-04-30** ([release schedule](https://nodejs.org/en/about/previous-releases)). This PR aligns the project with that:

- `engines.node`: `>=20` → `>=22`
- CI matrix: `[20, 22, 24]` → `[22, 24]`
- README requirement: `Node.js >= 22`
- Changeset queued for **v0.6.0** (pre-1.0 minor — convention used by this project for support-range tightenings; see #113)

Runtime API is unchanged. This PR only narrows the supported runtime range.

## Why a minor bump

This project is pre-1.0, where minor bumps absorb breaking-ish changes (per [SemVer §4](https://semver.org/#spec-item-4) and the project's own release log). Even though `engines` is advisory in npm rather than enforced, raising the floor is a meaningful contract change for anyone pinning Node 20 — they need a release boundary to know when to upgrade.

## For consumers still on Node 20

Pin `hono-problem-details` to `<0.6.0` until you can upgrade Node. Node 20 will not receive further upstream security patches, so the upgrade is recommended regardless.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 195/195 passed
- [x] `pnpm build` — clean
- [x] `pnpm test:compat` — clean (TS compat matrix unaffected by Node bump)
- [ ] CI matrix runs on `[22, 24]` only (verified after push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
