### PR TITLE
chore(deps): bump pnpm 10.14.0 -> 10.33.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
 	"engines": {
 		"node": ">=22"
 	},
-	"packageManager": "pnpm@10.14.0",
+	"packageManager": "pnpm@10.33.2",
 	"pnpm": {
 		"onlyBuiltDependencies": [
 			"@biomejs/biome",


### PR DESCRIPTION
## Summary

Patch-level update of the packageManager field (10.14.0 -> 10.33.2). CI consumes this via corepack, so the bump applies uniformly across local + CI without workflow changes. The pnpm 10.x lockfile format is stable across patches — pnpm-lock.yaml is unchanged.

Dev-tooling only; no runtime impact, no changeset.

## Test plan

- [x] pnpm install — Lockfile is up to date, resolution step is skipped
- [x] pnpm lint — clean
- [x] pnpm typecheck — clean
- [x] pnpm test — 195/195 passed
- [x] pnpm build — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)