### PR TITLE
chore(deps-dev): bump TypeScript 5.7 -> 6.0 with ignoreDeprecations

### DIFF
--- a/.changeset/ts6-phase2-compat.md
+++ b/.changeset/ts6-phase2-compat.md
@@ -1,0 +1,9 @@
+---
+"hono-problem-details": patch
+---
+
+Verify TypeScript 6.0 consumer compatibility in CI
+
+The CI `type-compat` matrix now also runs against TypeScript 6.0.3, in addition to 5.0.4 / 5.4.5 / 5.7.3 / 5.9.3. Dev TypeScript was also bumped to 6.0.3, paired with `"ignoreDeprecations": "6.0"` in `tsconfig.json` to silence the `TS5101` triggered by `tsup`'s injected `baseUrl` in DTS bundling (see [tsup#1388](https://github.com/egoist/tsup/issues/1388)). The published `.d.ts` shape is unchanged; this PR only widens the verified consumer matrix.
+
+The compat consumer (`tests/type-compat/core-consumer.ts`) was extended to import every published subpath (`./zod`, `./valibot`, `./openapi`, `./standard-schema`) so future TS bumps are guarded across the whole public surface, not just the core entry point.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ts: ["5.0.4", "5.4.5", "5.7.3", "5.9.3"]
+        ts: ["5.0.4", "5.4.5", "5.7.3", "5.9.3", "6.0.3"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ npm install hono-problem-details
 ### Requirements
 
 - Hono `>= 4.12.14` (peer dependency)
-- TypeScript `>= 5.0` — the published `.d.ts` files are CI-tested against TS 5.0, 5.4, 5.7, and 5.9. Older TS versions may work but are not verified.
+- TypeScript `>= 5.0` — the published `.d.ts` files are CI-tested against TS 5.0, 5.4, 5.7, 5.9, and 6.0. Older TS versions may work but are not verified.
 - Node.js `>= 22` (Node 20 reached end-of-life in April 2026; v0.6.0 raised the floor)
 
 ## Quick Start

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
 		"hono": "^4.12.14",
 		"lefthook": "2.1.6",
 		"tsup": "^8.0.0",
-		"typescript": "^5.7.0",
+		"typescript": "^6.0.3",
 		"valibot": "^1.3.1",
 		"vitest": "^3.0.0",
 		"zod": "^4.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 0.2.2(@standard-schema/spec@1.1.0)(hono@4.12.15)
       '@hono/valibot-validator':
         specifier: ^0.6.1
-        version: 0.6.1(hono@4.12.15)(valibot@1.3.1(typescript@5.9.3))
+        version: 0.6.1(hono@4.12.15)(valibot@1.3.1(typescript@6.0.3))
       '@hono/zod-openapi':
         specifier: 1.3.0
         version: 1.3.0(hono@4.12.15)(zod@4.3.6)
@@ -43,13 +43,13 @@ importers:
         version: 2.1.6
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.13)(typescript@5.9.3)(yaml@2.8.2)
+        version: 8.5.1(postcss@8.5.13)(typescript@6.0.3)(yaml@2.8.2)
       typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       valibot:
         specifier: ^1.3.1
-        version: 1.3.1(typescript@5.9.3)
+        version: 1.3.1(typescript@6.0.3)
       vitest:
         specifier: ^3.0.0
         version: 3.2.4(yaml@2.8.2)
@@ -115,24 +115,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.4.14':
     resolution: {integrity: sha512-2TELhZnW5RSLL063l9rc5xLpA0ZIw0Ccwy/0q384rvNAgFw3yI76bd59547yxowdQr5MNPET/xDLrLuvgSeeWQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.4.14':
     resolution: {integrity: sha512-R6BWgJdQOwW9ulJatuTVrQkjnODjqHZkKNOqb1sz++3Noe5LYd0i3PchnOBUCYAPHoPWHhjJqbdZlHEu0hpjdA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.4.14':
     resolution: {integrity: sha512-zHrlQZDBDUz4OLAraYpWKcnLS6HOewBFWYOzY91d1ZjdqZwibOyb6BEu6WuWLugyo0P3riCmsbV9UqV1cSXwQg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.4.14':
     resolution: {integrity: sha512-M3EH5hqOI/F/FUA2u4xcLoUgmxd218mvuj/6JL7Hv2toQvr2/AdOvKSpGkoRuWFCtQPVa+ZqkEV3Q5xBA9+XSA==}
@@ -474,66 +478,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -1368,8 +1385,8 @@ packages:
       typescript:
         optional: true
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -1798,10 +1815,10 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       hono: 4.12.15
 
-  '@hono/valibot-validator@0.6.1(hono@4.12.15)(valibot@1.3.1(typescript@5.9.3))':
+  '@hono/valibot-validator@0.6.1(hono@4.12.15)(valibot@1.3.1(typescript@6.0.3))':
     dependencies:
       hono: 4.12.15
-      valibot: 1.3.1(typescript@5.9.3)
+      valibot: 1.3.1(typescript@6.0.3)
 
   '@hono/zod-openapi@1.3.0(hono@4.12.15)(zod@4.3.6)':
     dependencies:
@@ -2693,7 +2710,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tsup@8.5.1(postcss@8.5.13)(typescript@5.9.3)(yaml@2.8.2):
+  tsup@8.5.1(postcss@8.5.13)(typescript@6.0.3)(yaml@2.8.2):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.3)
       cac: 6.7.14
@@ -2714,22 +2731,22 @@ snapshots:
       tree-kill: 1.2.2
     optionalDependencies:
       postcss: 8.5.13
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - jiti
       - supports-color
       - tsx
       - yaml
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   ufo@1.6.3: {}
 
   universalify@0.1.2: {}
 
-  valibot@1.3.1(typescript@5.9.3):
+  valibot@1.3.1(typescript@6.0.3):
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   vite-node@3.2.4(yaml@2.8.2):
     dependencies:

--- a/tests/type-compat/core-consumer.ts
+++ b/tests/type-compat/core-consumer.ts
@@ -12,6 +12,14 @@ import {
 	statusToPhrase,
 	statusToSlug,
 } from "../../dist/index.js";
+import {
+	createProblemDetailsSchema,
+	ProblemDetailsSchema,
+	problemDetailsResponse,
+} from "../../dist/integrations/openapi.js";
+import { standardSchemaProblemHook } from "../../dist/integrations/standard-schema.js";
+import { valibotProblemHook } from "../../dist/integrations/valibot.js";
+import { zodProblemHook } from "../../dist/integrations/zod.js";
 
 const _ct: typeof PROBLEM_JSON_CONTENT_TYPE = PROBLEM_JSON_CONTENT_TYPE;
 
@@ -56,6 +64,13 @@ const _registryError: ProblemDetailsError = _registry.create("ORDER_CONFLICT", {
 const _phrase: string | undefined = statusToPhrase(404);
 const _slug: string | undefined = statusToSlug(404);
 
+const _zodHook = zodProblemHook();
+const _valibotHook = valibotProblemHook();
+const _standardHook = standardSchemaProblemHook();
+const _problemSchema = ProblemDetailsSchema;
+const _problemSchemaFactory = createProblemDetailsSchema;
+const _problemResponse = problemDetailsResponse;
+
 void _ct;
 void _problem;
 void _input;
@@ -67,3 +82,9 @@ void _registry;
 void _registryError;
 void _phrase;
 void _slug;
+void _zodHook;
+void _valibotHook;
+void _standardHook;
+void _problemSchema;
+void _problemSchemaFactory;
+void _problemResponse;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
 		"skipLibCheck": true,
 		"isolatedModules": true,
 		"forceConsistentCasingInFileNames": true,
+		"ignoreDeprecations": "6.0",
 		"declaration": true,
 		"declarationMap": true,
 		"sourceMap": true,


### PR DESCRIPTION
## Summary

Phase 2 of the TypeScript support strategy started in #121: bump dev TypeScript to 6.0.3 and extend the CI `type-compat` matrix so the published `.d.ts` is verified against TS 5.0 / 5.4 / 5.7 / 5.9 / **6.0**.

The published `.d.ts` shape is unchanged — this PR only widens the verified consumer matrix and adds the `ignoreDeprecations` workaround required to build under TS 6.

## Changes

- **`package.json`** — devDependency `typescript` `^5.7.0` → `^6.0.3`
- **`tsconfig.json`** — add `"ignoreDeprecations": "6.0"` to silence `TS5101` from `tsup`'s injected `baseUrl` in DTS bundling. Tracked upstream as [tsup#1388](https://github.com/egoist/tsup/issues/1388); the option is the official TS 6 escape hatch and is removed in TS 7
- **`tests/type-compat/core-consumer.ts`** — import every published subpath (`./zod`, `./valibot`, `./openapi`, `./standard-schema`) so the matrix guards the full public API surface, not just the core entry point
- **`.github/workflows/ci.yml`** — add `"6.0.3"` to the `type-compat` matrix
- **`README.md`** — TS support line updated to mention 6.0
- **changeset** — `patch` (no API change; bumps the documented support guarantee)

## Why now

#121 set up the matrix as a safety net specifically so that future TS bumps could be verified rather than taken on faith. Local matrix simulation confirms TS 5.0.4 / 5.4.5 / 5.7.3 / 5.9.3 / 6.0.3 all pass against the dist built under TS 6.0.3, so the safety net catches what we wanted it to catch. The blocker (`TS5101` from tsup's hardcoded `baseUrl: "."`) is unavoidable from project config alone, and `ignoreDeprecations: "6.0"` is the canonical workaround.

## Test plan

- [x] `pnpm lint` — 33 files, 0 issues
- [x] `pnpm typecheck` (under TS 6.0.3) — 0 errors
- [x] `pnpm test` — 195/195 passed
- [x] `pnpm build` — DTS bundle now succeeds under TS 6 (was the blocker)
- [x] Local matrix simulation: TS 5.0.4 / 5.4.5 / 5.7.3 / 5.9.3 / 6.0.3 all pass `tsc -p tsconfig.compat.json` against the TS6-built dist
- [ ] CI `type-compat` matrix passes on all 5 TS versions

## Notes

- `ignoreDeprecations` lives in `tsconfig.json` only; it does not appear in the emitted `.d.ts`, so consumers on TS 5.x are unaffected
- Phase 2 closes the deferred work tracked in the project's TS6 reference notes; the long-term answer (replace tsup with `tsdown` / `unbuild`) remains open
- Effective LOC excluding `pnpm-lock.yaml`: ~28

🤖 Generated with [Claude Code](https://claude.com/claude-code)