### PR TITLE
fix(openapi): standard fields win over extensions + lazy test spy fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,9 @@ pnpm build             # tsup (ESM + CJS dual output)
 
 ## Key Conventions
 
-- **Extensions spread order**: `{ ...extensions, ...standard }` — standard fields always win over extensions (RFC 9457 Section 3.1)
+- **Standard fields always win over extensions** (RFC 9457 §3.1). Enforce in both layers:
+  - Runtime factory (`problemDetails()`): spread as `{ ...extensions, ...standard }` so the standard properties land last
+  - OpenAPI schema (`createProblemDetailsSchema()`): filter standard field keys out of the extension shape before `.extend()` — Zod's `.extend()` would otherwise let conflicting keys replace standard fields
 - **Subpath exports**: Each integration is a separate entry point (`./zod`, `./valibot`, `./openapi`, `./standard-schema`)
 - **External deps**: All peer dependencies must be listed in `tsup.config.ts` `external` array to prevent bundling
 - **No runtime dependencies**: Only `hono` as peer dependency. All integrations are optional peer deps.

--- a/src/integrations/openapi.ts
+++ b/src/integrations/openapi.ts
@@ -37,14 +37,23 @@ export function getProblemDetailsSchema(): z.ZodObject<ProblemDetailsShape> {
 	return _cached;
 }
 
+const STANDARD_FIELD_KEYS = new Set(["type", "status", "title", "detail", "instance"]);
+
 /**
  * Create a Problem Details schema with typed extension members.
- * Extensions are merged at top level per RFC 9457.
+ *
+ * Extensions are merged at top level per RFC 9457 §3.1, and **standard fields
+ * always win** over extension keys that collide (mirroring the runtime spread
+ * order in `problemDetails()`). Conflicting extension keys are silently
+ * dropped from the schema.
  */
 export function createProblemDetailsSchema<T extends z.ZodRawShape>(
 	extensions: z.ZodObject<T>,
 ): z.ZodObject {
-	return getProblemDetailsSchema().extend(extensions.shape).openapi({ title: "ProblemDetails" });
+	const safeShape = Object.fromEntries(
+		Object.entries(extensions.shape).filter(([key]) => !STANDARD_FIELD_KEYS.has(key)),
+	);
+	return getProblemDetailsSchema().extend(safeShape).openapi({ title: "ProblemDetails" });
 }
 
 /**

--- a/tests/integrations/openapi-lazy.test.ts
+++ b/tests/integrations/openapi-lazy.test.ts
@@ -6,13 +6,20 @@
  * chained `.openapi(...)` calls before the consumer's bundle has finished
  * resolving and patching `zod`, which throws under multi-zod-instance bundles
  * (Cloudflare Workers via wrangler/esbuild, pnpm strict hoisting, etc.).
+ *
+ * NOTE: `vi.resetModules()` clears the module registry so subsequent dynamic
+ * imports re-evaluate. To attach spies to the prototype that the
+ * freshly-imported module will actually use, we must import `z` dynamically
+ * AFTER the reset — a top-level `import { z } from "@hono/zod-openapi"`
+ * would hold a stale reference to the pre-reset prototype, and the spy would
+ * never intercept calls made by the fresh module instance.
  */
-import { z } from "@hono/zod-openapi";
 import { describe, expect, it, vi } from "vitest";
 
 describe("openapi factory — lazy construction (ADR-0004)", () => {
 	it("L1: importing the module does not invoke `.openapi()`", async () => {
 		vi.resetModules();
+		const { z } = await import("@hono/zod-openapi");
 		const spy = vi.spyOn(z.ZodType.prototype, "openapi");
 		try {
 			await import("../../src/integrations/openapi.js");
@@ -24,6 +31,7 @@ describe("openapi factory — lazy construction (ADR-0004)", () => {
 
 	it("L2: `getProblemDetailsSchema()` triggers `.openapi()` invocations", async () => {
 		vi.resetModules();
+		const { z } = await import("@hono/zod-openapi");
 		const spy = vi.spyOn(z.ZodType.prototype, "openapi");
 		try {
 			const mod = await import("../../src/integrations/openapi.js");
@@ -52,6 +60,7 @@ describe("openapi factory — lazy construction (ADR-0004)", () => {
 
 	it("L5: `problemDetailsResponse()` invocation alone does not call `.openapi()` more than once per memoized build", async () => {
 		vi.resetModules();
+		const { z } = await import("@hono/zod-openapi");
 		const mod = await import("../../src/integrations/openapi.js");
 		// First call builds (and registers metadata via .openapi)
 		mod.problemDetailsResponse(400);

--- a/tests/integrations/openapi.test.ts
+++ b/tests/integrations/openapi.test.ts
@@ -113,6 +113,39 @@ describe("createProblemDetailsSchema", () => {
 		}
 	});
 
+	it("O16: extension keys conflicting with RFC 9457 standard fields are ignored (standard wins)", () => {
+		// CLAUDE.md: "Extensions spread order: { ...extensions, ...standard } —
+		// standard fields always win over extensions (RFC 9457 Section 3.1)".
+		// The runtime factory (problemDetails()) enforces this via spread order;
+		// the OpenAPI schema must enforce the same invariant at schema build time.
+		const schema = createProblemDetailsSchema(
+			z.object({
+				// Conflicting key: would otherwise replace `status: z.number().int()`.
+				status: z.string(),
+				// Non-conflicting extension key remains.
+				traceId: z.string(),
+			}),
+		);
+
+		// Standard `status` is still a number — extension's z.string() did not win.
+		const numericOk = schema.safeParse({
+			type: "about:blank",
+			status: 500,
+			title: "Server Error",
+			traceId: "abc",
+		});
+		expect(numericOk.success).toBe(true);
+
+		// Strings fail because the standard z.number().int() is preserved.
+		const stringFails = schema.safeParse({
+			type: "about:blank",
+			status: "not-a-number",
+			title: "Server Error",
+			traceId: "abc",
+		});
+		expect(stringFails.success).toBe(false);
+	});
+
 	it("O8: extension schema preserves 'ProblemDetails' title in generated doc", () => {
 		const customSchema = createProblemDetailsSchema(
 			z.object({


### PR DESCRIPTION
## Summary

Two issues caught after #135 landed.

### 1. Extension keys could overwrite RFC 9457 standard fields

`createProblemDetailsSchema()` previously did `getProblemDetailsSchema().extend(extensions.shape)`. Zod's `.extend()` lets the passed-in shape replace existing keys, so a caller passing `z.object({ status: z.string() })` would silently override the standard `status: z.number().int()` — violating RFC 9457 §3.1 and the runtime factory's "standard always wins" invariant.

Fix: filter standard field keys out of the extension shape before `.extend()`. Conflicting extension keys are silently dropped, matching the runtime factory's spread-order behavior.

`CLAUDE.md` now documents this requirement for both the runtime factory and the OpenAPI schema, so future contributors can see the contract applies in both layers.

### 2. Lazy-construction tests attached spies to stale prototypes

The `openapi-lazy.test.ts` tests imported `z` at the top of the file, then called `vi.resetModules()` inside each test before dynamic-importing the module under test. After `vi.resetModules()`, the fresh dynamic import re-evaluates `@hono/zod-openapi` and `zod`, giving the freshly-imported module a different `ZodType.prototype` than the top-level `z` reference points to. The `vi.spyOn(z.ZodType.prototype, "openapi")` was therefore on a stale prototype that the freshly-imported module never touched:

- L1 (assert not called): could pass vacuously
- L5 (assert not called after first build): could pass vacuously
- L2 (assert called after factory invocation): could fail

Fix: move the `z` import inside each affected test so it's dynamic-imported AFTER `vi.resetModules()`. The spy then lands on the prototype the test actually exercises.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 201/201 pass (O16 added)
- [x] Coverage 100% maintained
- [x] New test O16: extension with conflicting `status: z.string()` is rejected at parse time, proving the standard `z.number().int()` was preserved

Refs #135 (post-merge review feedback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OpenAPI problem-details schema generation now correctly prioritizes RFC 9457 standard fields (`type`, `status`, `title`, `detail`, `instance`) when extension fields share the same names.

* **Documentation**
  * Updated conventions to clarify standard field precedence in schema generation and runtime behavior.

* **Tests**
  * Added test case validating extension field conflicts are handled correctly.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/paveg/hono-problem-details/pull/137)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->