### PR TITLE
docs: point contributors to changeset-bot for adding changesets

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,3 +13,6 @@
 - [ ] `pnpm typecheck` passes
 - [ ] `pnpm lint` passes
 - [ ] Changeset added (if user-facing change)
+      — run `pnpm changeset` locally, or use the
+      [changeset-bot](https://github.com/apps/changeset-bot)
+      comment that appears on this PR

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ pnpm install
 3. **Write tests first** (TDD: Red → Green → Refactor)
 4. Implement the feature
 5. Ensure all checks pass: `pnpm typecheck && pnpm lint && pnpm test && pnpm build`
-6. Run `pnpm changeset` to create a changeset
+6. Add a changeset — either run `pnpm changeset` locally, or open the PR first and follow the link in the [changeset-bot](https://github.com/apps/changeset-bot) comment to add one from the web UI
 7. Submit a pull request
 
 ## Code Style


### PR DESCRIPTION
## Summary

- Mention [changeset-bot](https://github.com/apps/changeset-bot) as an alternative to running `pnpm changeset` locally, both in `PULL_REQUEST_TEMPLATE.md` and `CONTRIBUTING.md`.
- Lowers the friction for external contributors who don't want to clone + run pnpm just to add a changeset (the bot lets them add one from the GitHub web UI).

## Follow-up (manual, outside this PR)

- [ ] Install changeset-bot on the repository: <https://github.com/apps/changeset-bot>
  - GitHub App installation can't be automated via CLI — needs to be done in the web UI.
  - Until installed, the PR template / CONTRIBUTING.md link points to the app page, which is still useful (contributors know the option exists), but no auto-comment will appear on new PRs yet.

## Test plan

- [ ] Confirm the PR template renders the checklist item with the bot link as a continuation line (not a broken list)
- [ ] Confirm the `CONTRIBUTING.md` workflow step still parses as numbered list item 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pull request template and contribution guidelines to clarify the changeset submission process. Contributors can now submit changesets either locally or through the changeset-bot interface available in pull requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/paveg/hono-problem-details/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->