### PR TITLE
chore: remove stale NPM_TOKEN / NODE_AUTH_TOKEN references

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     # restricts the head branch of the triggering CI run. A CI run started by a
     # `pull_request` event can still satisfy that filter, so we must also require
     # the triggering event to be `push` and the head branch to be literally `main`
-    # before exposing NPM_TOKEN / id-token.
+    # before exposing id-token.
     if: >-
       github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.head_branch == 'main' &&

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,5 +67,4 @@ pnpm build             # tsup (ESM + CJS dual output)
 
 - Changesets for versioning (`pnpm changeset`)
 - GitHub Actions auto-creates "Version Packages" PR on main push
-- Merging that PR triggers `pnpm release` (build + publish to npm)
-- `NODE_AUTH_TOKEN` env var required for npm auth in CI
+- Merging that PR triggers `pnpm release` (build + publish to npm via OIDC Trusted Publishing)


### PR DESCRIPTION
## Summary

- Remove `NODE_AUTH_TOKEN` line from `CLAUDE.md` — the release pipeline uses npm OIDC Trusted Publishing (`id-token: write`), not secret-based auth
- Update `release.yml` comment to drop the stale `NPM_TOKEN` mention

## Test plan

- [ ] Docs-only change — no functional impact
- [ ] Verify `release.yml` still runs correctly on next Version Packages merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release process documentation to reflect current npm authentication method.

* **Chores**
  * Updated CI/CD workflow configuration and comments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/paveg/hono-problem-details/pull/142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->