### PR TITLE
chore: drop sourcemaps from published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,8 +75,7 @@
 		}
 	},
 	"files": [
-		"dist",
-		"!dist/**/*.map"
+		"dist"
 	],
 	"sideEffects": false,
 	"scripts": {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
 	format: ["esm", "cjs"],
 	dts: true,
 	clean: true,
-	sourcemap: true,
+	sourcemap: false,
 	external: [
 		"hono",
 		"zod",


### PR DESCRIPTION
## Why

The build set `sourcemap: true` but excluded `.map` files via `"!dist/**/*.map"` in `files`. This left published `dist/*.js` with dangling `//# sourceMappingURL=...map` comments pointing at maps that were never shipped — the worst of both worlds (broken reference, no working maps).

## What

- `tsup.config.ts`: `sourcemap: true` → `sourcemap: false` (no maps generated, no `sourceMappingURL` comment emitted)
- `package.json`: `files` simplified to `["dist"]` (the `.map` exclusion is now moot)

## Evidence / ecosystem alignment

Checked published npm tarballs of peer libraries:

| Library | ships `.map` |
|---|---|
| hono, zod, valibot, @standard-schema/spec | ❌ no |
| @hono/zod-validator, @hono/zod-openapi, @hono/valibot-validator | ✅ yes (tsup default) |

The foundational/minimal peers this library aligns with all strip maps. The `@hono/*` middleware that ship them do so via the unexamined `files: ["dist"]` tsup default.

## Verification

- `pnpm build` → dist 204K → **116K**, zero `.map`, zero `sourceMappingURL` comments
- Published tarball: 28 files, 0 maps, unpacked **72K**
- `pnpm lint` ✅ / `pnpm typecheck` ✅

No runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package publishing to include only distribution files.
  * Disabled source map generation in production builds.
  * Reduced the published package contents by excluding source map artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->