### PR TITLE
chore: add changeset for dropped sourcemaps

### DIFF
--- a/.changeset/drop-published-sourcemaps.md
+++ b/.changeset/drop-published-sourcemaps.md
@@ -1,0 +1,5 @@
+---
+"hono-problem-details": patch
+---
+
+Drop source maps from the published package. The build previously set `sourcemap: true` while excluding `.map` files via `files`, which left dangling `//# sourceMappingURL` comments pointing at maps that were never shipped. `sourcemap` is now `false`, so no source-map comments or files are emitted. Aligns with the minimal-footprint peers (hono, zod, valibot). No runtime behavior change.


### PR DESCRIPTION
Follow-up to #161, which was merged without a changeset.

#161 dropped source maps from the published package (`sourcemap: false`, `files: ["dist"]`), removing the `.map` files and the dangling `//# sourceMappingURL` comments from the tarball. That change is already on `main` but carries no changelog entry or version bump on its own.

This PR adds a `patch` changeset so the fix ships as its own release with a proper changelog entry. No code change — changeset only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)