### PR TITLE
fix: clamp body status and apply type options to thrown errors

### DIFF
--- a/.changeset/apply-type-options-to-thrown-errors.md
+++ b/.changeset/apply-type-options-to-thrown-errors.md
@@ -1,0 +1,5 @@
+---
+"hono-problem-details": minor
+---
+
+`typePrefix` and `defaultType` now apply to errors thrown via `problemDetails()` / registry `create()` and to `mapError` results when no explicit `type` was set. Previously these handler options only affected `HTTPException` and unhandled errors, silently leaving `about:blank` on the library's primary API. An explicitly set `type` (including an explicit `"about:blank"`) is never overridden.

--- a/.changeset/clamp-body-status.md
+++ b/.changeset/clamp-body-status.md
@@ -1,0 +1,5 @@
+---
+"hono-problem-details": patch
+---
+
+The JSON body's `status` field is now clamped to the same 200-599 range as the HTTP response status. Previously `problemDetails({ status: 9999 })` produced an HTTP 500 response whose body still said `"status": 9999`, contradicting RFC 9457's expectation that the body `status` mirrors the response status.

--- a/src/error.ts
+++ b/src/error.ts
@@ -11,6 +11,12 @@ export class ProblemDetailsError extends Error {
 	readonly problemDetails: ProblemDetails;
 
 	/**
+	 * Whether the input carried an explicit `type`. Lets the handler apply
+	 * `typePrefix`/`defaultType` only when the thrower left `type` unset.
+	 */
+	readonly hasExplicitType: boolean;
+
+	/**
 	 * @param input - Missing `type` defaults to `"about:blank"`;
 	 * missing `title` is derived from the HTTP status code.
 	 */
@@ -19,6 +25,7 @@ export class ProblemDetailsError extends Error {
 		super(pd.detail ?? pd.title);
 		this.name = "ProblemDetailsError";
 		this.problemDetails = pd;
+		this.hasExplicitType = input.type !== undefined;
 	}
 
 	/** Build a standalone `application/problem+json` Response without the handler middleware. */

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -19,7 +19,10 @@ function toResponse(
 	c: Context,
 	options: ProblemDetailsHandlerOptions,
 ): Response {
-	let pd = normalizeProblemDetails(input);
+	let pd = normalizeProblemDetails({
+		...input,
+		type: input.type ?? buildType(input.status, options),
+	});
 
 	if (options.autoInstance && pd.instance === undefined) {
 		pd = { ...pd, instance: c.req.path };
@@ -66,7 +69,8 @@ function toResponse(
 export function problemDetailsHandler(options: ProblemDetailsHandlerOptions = {}): ErrorHandler {
 	return (error, c) => {
 		if (error instanceof ProblemDetailsError) {
-			return toResponse(error.problemDetails, c, options);
+			const pd = error.problemDetails;
+			return toResponse(error.hasExplicitType ? pd : { ...pd, type: undefined }, c, options);
 		}
 
 		if (options.mapError) {
@@ -80,7 +84,6 @@ export function problemDetailsHandler(options: ProblemDetailsHandlerOptions = {}
 			return toResponse(
 				{
 					status: error.status,
-					type: buildType(error.status, options),
 					title: statusToPhrase(error.status),
 					detail: error.message,
 				},
@@ -92,7 +95,6 @@ export function problemDetailsHandler(options: ProblemDetailsHandlerOptions = {}
 		return toResponse(
 			{
 				status: 500,
-				type: buildType(500, options),
 				title: "Internal Server Error",
 				detail: "An unexpected error occurred",
 				extensions: options.includeStack ? { stack: error.stack } : undefined,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,10 +49,11 @@ export function normalizeProblemDetails<T extends Record<string, unknown>>(
 /** Build a RFC 9457 Problem Details Response from a ProblemDetails object */
 export function buildProblemResponse(pd: ProblemDetails): Response {
 	const { extensions, ...standard } = pd;
-	const body = { ...sanitizeExtensions(extensions), ...standard };
+	const status = clampHttpStatus(pd.status);
+	const body = { ...sanitizeExtensions(extensions), ...standard, status };
 	const { json, fallback } = safeStringify(body);
 	return new Response(json, {
-		status: fallback ? 500 : clampHttpStatus(pd.status),
+		status: fallback ? 500 : status,
 		headers: { "Content-Type": PROBLEM_JSON_CONTENT_TYPE },
 	});
 }

--- a/tests/factory.test.ts
+++ b/tests/factory.test.ts
@@ -125,11 +125,11 @@ describe("problemDetails factory", () => {
 		expect(response.status).toBe(500);
 	});
 
-	it("F14: getResponse() preserves original status in body even when HTTP status is clamped", async () => {
+	it("F14: getResponse() clamps body status to match the clamped HTTP status", async () => {
 		const error = problemDetails({ status: 9999 });
 		const response = error.getResponse();
 		const body = await response.json();
-		expect(body.status).toBe(9999);
+		expect(body.status).toBe(500);
 		expect(response.status).toBe(500);
 	});
 

--- a/tests/handler.test.ts
+++ b/tests/handler.test.ts
@@ -3,6 +3,7 @@ import { HTTPException } from "hono/http-exception";
 import { describe, expect, it, vi } from "vitest";
 import { problemDetails } from "../src/factory.js";
 import { problemDetailsHandler } from "../src/handler.js";
+import { createProblemTypeRegistry } from "../src/registry.js";
 import type { OtelApiLike } from "../src/types.js";
 
 function createApp(options?: Parameters<typeof problemDetailsHandler>[0]) {
@@ -374,7 +375,7 @@ describe("problemDetailsHandler", () => {
 		const res = await app.request("/");
 		expect(res.status).toBe(500);
 		const body = await res.json();
-		expect(body.status).toBe(9999);
+		expect(body.status).toBe(500);
 	});
 
 	it("H25: clamps negative status code to 500", async () => {
@@ -412,7 +413,7 @@ describe("problemDetailsHandler", () => {
 			const res = await app.request("/");
 			expect(res.status).toBe(500);
 			const body = await res.json();
-			expect(body.status).toBe(status);
+			expect(body.status).toBe(500);
 		}
 	});
 
@@ -755,5 +756,62 @@ describe("problemDetailsHandler", () => {
 		const body = await res.json();
 		expect(body.requestId).toBe("req-1");
 		expect(body.traceId).toBe("test-trace-id");
+	});
+
+	it("H50: defaultType applies to problemDetails() thrown without a type", async () => {
+		const app = createApp({ defaultType: "https://api.example.com/errors/unknown" });
+		app.get("/", () => {
+			throw problemDetails({ status: 404 });
+		});
+		const res = await app.request("/");
+		const body = await res.json();
+		expect(body.type).toBe("https://api.example.com/errors/unknown");
+	});
+
+	it("H51: typePrefix applies to problemDetails() thrown without a type", async () => {
+		const app = createApp({ typePrefix: "https://api.example.com/problems" });
+		app.get("/", () => {
+			throw problemDetails({ status: 404 });
+		});
+		const res = await app.request("/");
+		const body = await res.json();
+		expect(body.type).toBe("https://api.example.com/problems/not-found");
+	});
+
+	it("H52: explicit about:blank is not overridden by defaultType", async () => {
+		const app = createApp({ defaultType: "https://api.example.com/errors/unknown" });
+		app.get("/", () => {
+			throw problemDetails({ status: 404, type: "about:blank" });
+		});
+		const res = await app.request("/");
+		const body = await res.json();
+		expect(body.type).toBe("about:blank");
+	});
+
+	it("H53: defaultType applies to mapError results without a type", async () => {
+		const app = createApp({
+			defaultType: "https://api.example.com/errors/unknown",
+			mapError: () => ({ status: 422, title: "Mapped" }),
+		});
+		app.get("/", () => {
+			throw new RangeError("boom");
+		});
+		const res = await app.request("/");
+		const body = await res.json();
+		expect(body.status).toBe(422);
+		expect(body.type).toBe("https://api.example.com/errors/unknown");
+	});
+
+	it("H54: typePrefix applies to registry-created errors without a type", async () => {
+		const problems = createProblemTypeRegistry({
+			outOfStock: { status: 409, title: "Out of Stock" },
+		});
+		const app = createApp({ typePrefix: "https://api.example.com/problems" });
+		app.get("/", () => {
+			throw problems.create("outOfStock");
+		});
+		const res = await app.request("/");
+		const body = await res.json();
+		expect(body.type).toBe("https://api.example.com/problems/conflict");
 	});
 });

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -190,7 +190,7 @@ describe("buildProblemResponse", () => {
 		});
 		expect(res.status).toBe(500);
 		const body = await res.json();
-		expect(body.status).toBe(9999);
+		expect(body.status).toBe(500);
 	});
 
 	it("U20: returns fallback on circular extensions", async () => {


### PR DESCRIPTION
## Summary

Implements the two behavior decisions left open by the adversarial audit (#167).

**Body `status` clamping (patch)**
`buildProblemResponse` clamped only the HTTP wire status, so `problemDetails({ status: 9999 })` returned HTTP 500 with a body literally saying `"status": 9999` — internally inconsistent and against RFC 9457's expectation that the body `status` mirrors the response status. The body now carries the same clamped value. Valid statuses are untouched (H33 guards 2xx passthrough).

**`typePrefix` / `defaultType` for thrown errors (minor)**
These handler options previously only affected `HTTPException` and unhandled errors: `normalizeProblemDetails` resolved a missing `type` to `about:blank` at throw time, before handler options exist. Now:

- `ProblemDetailsError` records `hasExplicitType` at construction.
- `toResponse` is the single type-resolution point (`input.type ?? buildType(...)`), so the fix uniformly covers `problemDetails()`, registry `create()`, and `mapError` results; the redundant per-branch `buildType` calls in the HTTPException/500 branches were removed.
- An explicitly set `type` — including an explicit `"about:blank"` — is never overridden (H31, H52).
- `getResponse()` (standalone, no handler) keeps the `about:blank` default, unchanged.

Tests were written first and confirmed failing (U19, H50-H54); three tests that encoded the old passthrough behavior (F14, H24, H27) were updated to the new invariant.

## Test plan

- Red confirmed before implementation: U19 + H50/H51/H53/H54 failed on main's behavior
- `pnpm vitest run --coverage` — 212/212 pass, 100% statements/branches/functions/lines
- `pnpm lint` / `pnpm typecheck` / `pnpm test:compat` / `pnpm knip` — clean
- Changesets: patch (status clamp) + minor (type options; observable `type` values change for apps that set these options and throw typeless errors) → next release 0.9.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)