### PR TITLE
fix: clamp the JSON body status to match the wire status

### DIFF
--- a/.changeset/clamp-body-status.md
+++ b/.changeset/clamp-body-status.md
@@ -1,0 +1,5 @@
+---
+"hono-problem-details": patch
+---
+
+The JSON body's `status` field is now clamped to the same 200-599 range as the HTTP response status. Previously `problemDetails({ status: 9999 })` produced an HTTP 500 response whose body still said `"status": 9999`, contradicting RFC 9457's expectation that the body `status` mirrors the response status.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,10 +49,11 @@ export function normalizeProblemDetails<T extends Record<string, unknown>>(
 /** Build a RFC 9457 Problem Details Response from a ProblemDetails object */
 export function buildProblemResponse(pd: ProblemDetails): Response {
 	const { extensions, ...standard } = pd;
-	const body = { ...sanitizeExtensions(extensions), ...standard };
+	const status = clampHttpStatus(pd.status);
+	const body = { ...sanitizeExtensions(extensions), ...standard, status };
 	const { json, fallback } = safeStringify(body);
 	return new Response(json, {
-		status: fallback ? 500 : clampHttpStatus(pd.status),
+		status: fallback ? 500 : status,
 		headers: { "Content-Type": PROBLEM_JSON_CONTENT_TYPE },
 	});
 }

--- a/tests/factory.test.ts
+++ b/tests/factory.test.ts
@@ -125,11 +125,11 @@ describe("problemDetails factory", () => {
 		expect(response.status).toBe(500);
 	});
 
-	it("F14: getResponse() preserves original status in body even when HTTP status is clamped", async () => {
+	it("F14: getResponse() clamps body status to match the clamped HTTP status", async () => {
 		const error = problemDetails({ status: 9999 });
 		const response = error.getResponse();
 		const body = await response.json();
-		expect(body.status).toBe(9999);
+		expect(body.status).toBe(500);
 		expect(response.status).toBe(500);
 	});
 

--- a/tests/handler.test.ts
+++ b/tests/handler.test.ts
@@ -374,7 +374,7 @@ describe("problemDetailsHandler", () => {
 		const res = await app.request("/");
 		expect(res.status).toBe(500);
 		const body = await res.json();
-		expect(body.status).toBe(9999);
+		expect(body.status).toBe(500);
 	});
 
 	it("H25: clamps negative status code to 500", async () => {
@@ -412,7 +412,7 @@ describe("problemDetailsHandler", () => {
 			const res = await app.request("/");
 			expect(res.status).toBe(500);
 			const body = await res.json();
-			expect(body.status).toBe(status);
+			expect(body.status).toBe(500);
 		}
 	});
 

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -190,7 +190,7 @@ describe("buildProblemResponse", () => {
 		});
 		expect(res.status).toBe(500);
 		const body = await res.json();
-		expect(body.status).toBe(9999);
+		expect(body.status).toBe(500);
 	});
 
 	it("U20: returns fallback on circular extensions", async () => {


### PR DESCRIPTION
## Summary

First of two PRs splitting #168 (one purpose per PR). Implements the R1 decision from the adversarial audit (#167).

`buildProblemResponse` clamped only the HTTP wire status, so `problemDetails({ status: 9999 })` returned HTTP 500 with a body literally saying `"status": 9999` — internally inconsistent and against RFC 9457's expectation that the body `status` mirrors the response status. The body now carries the same clamped value. Valid statuses are untouched (H33 guards 2xx passthrough).

Tests that encoded the old passthrough behavior — U19 (whose name already claimed clamping), F14, H24, H27 — are updated to the new invariant.

## Test plan

- U19 was confirmed failing against the old behavior before the fix
- `pnpm vitest run --coverage` — 207/207 pass, 100% coverage maintained
- `pnpm lint` / `pnpm typecheck` — clean
- Patch changeset included

🤖 Generated with [Claude Code](https://claude.com/claude-code)