### PR TITLE
fix: apply typePrefix/defaultType to thrown errors without a type

### DIFF
--- a/.changeset/apply-type-options-to-thrown-errors.md
+++ b/.changeset/apply-type-options-to-thrown-errors.md
@@ -1,0 +1,5 @@
+---
+"hono-problem-details": minor
+---
+
+`typePrefix` and `defaultType` now apply to errors thrown via `problemDetails()` / registry `create()` and to `mapError` results when no explicit `type` was set. Previously these handler options only affected `HTTPException` and unhandled errors, silently leaving `about:blank` on the library's primary API. An explicitly set `type` (including an explicit `"about:blank"`) is never overridden.

--- a/src/error.ts
+++ b/src/error.ts
@@ -11,6 +11,12 @@ export class ProblemDetailsError extends Error {
 	readonly problemDetails: ProblemDetails;
 
 	/**
+	 * Whether the input carried an explicit `type`. Lets the handler apply
+	 * `typePrefix`/`defaultType` only when the thrower left `type` unset.
+	 */
+	readonly hasExplicitType: boolean;
+
+	/**
 	 * @param input - Missing `type` defaults to `"about:blank"`;
 	 * missing `title` is derived from the HTTP status code.
 	 */
@@ -19,6 +25,7 @@ export class ProblemDetailsError extends Error {
 		super(pd.detail ?? pd.title);
 		this.name = "ProblemDetailsError";
 		this.problemDetails = pd;
+		this.hasExplicitType = input.type !== undefined;
 	}
 
 	/** Build a standalone `application/problem+json` Response without the handler middleware. */

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -19,7 +19,10 @@ function toResponse(
 	c: Context,
 	options: ProblemDetailsHandlerOptions,
 ): Response {
-	let pd = normalizeProblemDetails(input);
+	let pd = normalizeProblemDetails({
+		...input,
+		type: input.type ?? buildType(input.status, options),
+	});
 
 	if (options.autoInstance && pd.instance === undefined) {
 		pd = { ...pd, instance: c.req.path };
@@ -66,7 +69,8 @@ function toResponse(
 export function problemDetailsHandler(options: ProblemDetailsHandlerOptions = {}): ErrorHandler {
 	return (error, c) => {
 		if (error instanceof ProblemDetailsError) {
-			return toResponse(error.problemDetails, c, options);
+			const pd = error.problemDetails;
+			return toResponse(error.hasExplicitType ? pd : { ...pd, type: undefined }, c, options);
 		}
 
 		if (options.mapError) {
@@ -80,7 +84,6 @@ export function problemDetailsHandler(options: ProblemDetailsHandlerOptions = {}
 			return toResponse(
 				{
 					status: error.status,
-					type: buildType(error.status, options),
 					title: statusToPhrase(error.status),
 					detail: error.message,
 				},
@@ -92,7 +95,6 @@ export function problemDetailsHandler(options: ProblemDetailsHandlerOptions = {}
 		return toResponse(
 			{
 				status: 500,
-				type: buildType(500, options),
 				title: "Internal Server Error",
 				detail: "An unexpected error occurred",
 				extensions: options.includeStack ? { stack: error.stack } : undefined,

--- a/tests/handler.test.ts
+++ b/tests/handler.test.ts
@@ -3,6 +3,7 @@ import { HTTPException } from "hono/http-exception";
 import { describe, expect, it, vi } from "vitest";
 import { problemDetails } from "../src/factory.js";
 import { problemDetailsHandler } from "../src/handler.js";
+import { createProblemTypeRegistry } from "../src/registry.js";
 import type { OtelApiLike } from "../src/types.js";
 
 function createApp(options?: Parameters<typeof problemDetailsHandler>[0]) {
@@ -755,5 +756,62 @@ describe("problemDetailsHandler", () => {
 		const body = await res.json();
 		expect(body.requestId).toBe("req-1");
 		expect(body.traceId).toBe("test-trace-id");
+	});
+
+	it("H50: defaultType applies to problemDetails() thrown without a type", async () => {
+		const app = createApp({ defaultType: "https://api.example.com/errors/unknown" });
+		app.get("/", () => {
+			throw problemDetails({ status: 404 });
+		});
+		const res = await app.request("/");
+		const body = await res.json();
+		expect(body.type).toBe("https://api.example.com/errors/unknown");
+	});
+
+	it("H51: typePrefix applies to problemDetails() thrown without a type", async () => {
+		const app = createApp({ typePrefix: "https://api.example.com/problems" });
+		app.get("/", () => {
+			throw problemDetails({ status: 404 });
+		});
+		const res = await app.request("/");
+		const body = await res.json();
+		expect(body.type).toBe("https://api.example.com/problems/not-found");
+	});
+
+	it("H52: explicit about:blank is not overridden by defaultType", async () => {
+		const app = createApp({ defaultType: "https://api.example.com/errors/unknown" });
+		app.get("/", () => {
+			throw problemDetails({ status: 404, type: "about:blank" });
+		});
+		const res = await app.request("/");
+		const body = await res.json();
+		expect(body.type).toBe("about:blank");
+	});
+
+	it("H53: defaultType applies to mapError results without a type", async () => {
+		const app = createApp({
+			defaultType: "https://api.example.com/errors/unknown",
+			mapError: () => ({ status: 422, title: "Mapped" }),
+		});
+		app.get("/", () => {
+			throw new RangeError("boom");
+		});
+		const res = await app.request("/");
+		const body = await res.json();
+		expect(body.status).toBe(422);
+		expect(body.type).toBe("https://api.example.com/errors/unknown");
+	});
+
+	it("H54: typePrefix applies to registry-created errors without a type", async () => {
+		const problems = createProblemTypeRegistry({
+			outOfStock: { status: 409, title: "Out of Stock" },
+		});
+		const app = createApp({ typePrefix: "https://api.example.com/problems" });
+		app.get("/", () => {
+			throw problems.create("outOfStock");
+		});
+		const res = await app.request("/");
+		const body = await res.json();
+		expect(body.type).toBe("https://api.example.com/problems/conflict");
 	});
 });


### PR DESCRIPTION
## Summary

Second of two PRs splitting #168 (one purpose per PR). Implements the R2 decision from the adversarial audit (#167).

`typePrefix` / `defaultType` previously only affected `HTTPException` and unhandled errors: `normalizeProblemDetails` resolved a missing `type` to `about:blank` at throw time, before handler options exist, so the library's primary API (`problemDetails()`, registry `create()`) silently ignored them. Now:

- `ProblemDetailsError` records `hasExplicitType` at construction (additive public field).
- `toResponse` is the single type-resolution point (`input.type ?? buildType(...)`), uniformly covering `problemDetails()`, registry `create()`, and `mapError` results; the redundant per-branch `buildType` calls in the HTTPException/500 branches are removed.
- An explicitly set `type` — including an explicit `"about:blank"` — is never overridden (H31, H52).
- `getResponse()` (standalone, no handler) keeps the `about:blank` default, unchanged.

Minor changeset: observable `type` values change for apps that set these options and throw typeless errors (pre-1.0 convention: behavior changes ship as minor).

## Test plan

- H50/H51/H53/H54 were confirmed failing against the old behavior before the fix; H52 guards the explicit-about:blank case
- `pnpm vitest run --coverage` — 212/212 pass, 100% coverage maintained
- `pnpm lint` / `pnpm typecheck` / `pnpm test:compat` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)