### PR TITLE
chore: add TypeScript 7.0 to type-compat matrix

### DIFF
--- a/.changeset/ts7-type-compat.md
+++ b/.changeset/ts7-type-compat.md
@@ -1,0 +1,5 @@
+---
+"hono-problem-details": patch
+---
+
+Verify published type definitions against TypeScript 7.0 (native compiler). The type-compat CI matrix now covers TS 5.0, 5.4, 5.7, 5.9, 6.0, and 7.0, widening the documented consumer support guarantee. No runtime changes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ts: ["5.0.4", "5.4.5", "5.7.3", "5.9.3", "6.0.3"]
+        ts: ["5.0.4", "5.4.5", "5.7.3", "5.9.3", "6.0.3", "7.0.2"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ npm install hono-problem-details
 ### Requirements
 
 - Hono `>= 4.12.27` (peer dependency; floor raised for upstream security fixes)
-- TypeScript `>= 5.0` — the published `.d.ts` files are CI-tested against TS 5.0, 5.4, 5.7, 5.9, and 6.0. Older TS versions may work but are not verified.
+- TypeScript `>= 5.0` — the published `.d.ts` files are CI-tested against TS 5.0, 5.4, 5.7, 5.9, 6.0, and 7.0 (native compiler). Older TS versions may work but are not verified.
 - Node.js `>= 22` (Node 20 reached end-of-life in April 2026; v0.6.0 raised the floor)
 
 ## Quick Start


### PR DESCRIPTION
## Overview

Part of #177 (Phase 1). Widens the consumer-facing TypeScript support guarantee to TS 7.0 (native compiler) without touching the dev toolchain.

Dependabot's dev bump to `typescript@7.0.2` (#176) cannot merge: TS 7.0 ships without the programmatic JS API that tsup's DTS step depends on, so `pnpm build` crashes. Consumers are unaffected — they only read the published `.d.ts` files — so consumer support is verified here independently, and #176 was closed with `@dependabot ignore this major version`.

## Changes

- Add `7.0.2` to the `type-compat` CI matrix (static literal, existing quoted `env:` pattern)
- README requirements: document TS 7.0 in the CI-tested version list
- Changeset (patch): documents the widened support guarantee; no runtime changes

## Verification

- `pnpm dlx --package="typescript@7.0.2" -c 'tsc -p tsconfig.compat.json'` exits 0 locally against the current `dist`
- `pnpm lint` / `pnpm typecheck` / `pnpm test` (224 tests) all pass

## Notes

The dev-toolchain path to TS 7 (tsup → tsdown migration, then the actual dev bump) is deliberately deferred — tracked as Phase 2 in #177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented TypeScript 7.0 compatibility for the published type definitions.
* **Tests**
  * Expanded compatibility checks to include TypeScript 7.0 alongside supported versions.
* **Chores**
  * Prepared a patch release update for improved type-definition verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->