### PR TITLE
feat: add schema-agnostic JSON Schema OpenAPI helpers

### DIFF
--- a/.changeset/gold-planes-swim.md
+++ b/.changeset/gold-planes-swim.md
@@ -1,0 +1,7 @@
+---
+"hono-problem-details": minor
+---
+
+Add `hono-problem-details/openapi-json-schema`: schema-library-agnostic OpenAPI helpers for non-Zod stacks (#185).
+
+`problemDetailsJsonSchema()` emits the RFC 9457 Problem Details schema as plain JSON Schema (draft 2020-12, the OpenAPI 3.1 base dialect) with zero dependencies, and `problemDetailsResponseJsonSchema()` wraps it as a ready-to-use OpenAPI response object for `hono-openapi`'s `describeRoute()` and similar documentation layers. Extension members merge at the top level with standard fields winning on collision, mirroring the existing Zod helpers and the runtime (ADR-0002).

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ can all agree on.
 - **Hono native** — `app.onError` handler with RFC-compliant defaults
 - **Zod integration** — `@hono/zod-validator` hook for validation errors
 - **Valibot integration** — `@hono/valibot-validator` hook for validation errors
-- **OpenAPI integration** — `@hono/zod-openapi` schemas for API documentation
+- **OpenAPI integration** — `@hono/zod-openapi` schemas for API documentation, plus dependency-free plain JSON Schema helpers for non-Zod stacks
 - **OpenTelemetry integration** — `@opentelemetry/api` for automatically injecting trace information. 
 - **Standard Schema** — `@hono/standard-validator` hook (works with any schema library)
 - **Type-safe** — full TypeScript support with inference
@@ -451,6 +451,47 @@ const errorWithExtensions = createProblemDetailsSchema(
 > the const. The factory is memoized — repeat calls return the same instance.
 > See [ADR-0004](./docs/adr/0004-defer-openapi-schema-construction-via-factory.md)
 > for the bundler-related reason this changed.
+
+### Without Zod: plain JSON Schema
+
+Not on Zod? `hono-problem-details/openapi-json-schema` emits the same Problem Details
+schema as **plain JSON Schema** (draft 2020-12, the OpenAPI 3.1 base dialect) with zero
+dependencies. It works with any documentation layer that accepts raw JSON Schema — e.g.
+[`hono-openapi`](https://github.com/rhinobase/hono-openapi) on a Valibot, ArkType, or
+typia stack:
+
+```ts
+import { describeRoute } from "hono-openapi";
+import {
+  problemDetailsJsonSchema,
+  problemDetailsResponseJsonSchema,
+} from "hono-problem-details/openapi-json-schema";
+
+app.post(
+  "/reservations",
+  describeRoute({
+    responses: {
+      409: problemDetailsResponseJsonSchema(409, "Slot already taken"),
+      422: problemDetailsResponseJsonSchema(422),
+    },
+  }),
+  // ...
+);
+
+// Need the schema itself? With typed extension members:
+const schema = problemDetailsJsonSchema({
+  extensions: {
+    conflictingResources: { type: "array", items: { type: "string" } },
+  },
+});
+// Use: problemDetailsResponseJsonSchema(409, "Slot already taken", schema)
+```
+
+Extension members merge at the top level, and standard RFC 9457 fields win on key
+collision — the same rule the Zod helpers and the runtime follow
+([ADR-0002](./docs/adr/0002-extension-flatten-with-standard-field-precedence.md)).
+Each call returns a fresh object, so you can safely tweak the result (e.g. push extra
+keys into `required`) without affecting other call sites.
 
 ## Localization
 

--- a/README.md
+++ b/README.md
@@ -490,8 +490,11 @@ const schema = problemDetailsJsonSchema({
 Extension members merge at the top level, and standard RFC 9457 fields win on key
 collision — the same rule the Zod helpers and the runtime follow
 ([ADR-0002](./docs/adr/0002-extension-flatten-with-standard-field-precedence.md)).
-Each call returns a fresh object, so you can safely tweak the result (e.g. push extra
-keys into `required`) without affecting other call sites.
+Keys the runtime strips as prototype-pollution guards (`__proto__`, `constructor`,
+`prototype`) are excluded too, so the schema never documents a member that real
+responses omit. Each call returns a fresh object with extension schemas cloned, so
+you can safely tweak the result (e.g. push extra keys into `required`) without
+affecting other call sites or your own input.
 
 ## Localization
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,16 @@
 				"default": "./dist/integrations/openapi.cjs"
 			}
 		},
+		"./openapi-json-schema": {
+			"import": {
+				"types": "./dist/integrations/openapi-json-schema.d.ts",
+				"default": "./dist/integrations/openapi-json-schema.js"
+			},
+			"require": {
+				"types": "./dist/integrations/openapi-json-schema.d.cts",
+				"default": "./dist/integrations/openapi-json-schema.cjs"
+			}
+		},
 		"./standard-schema": {
 			"import": {
 				"types": "./dist/integrations/standard-schema.d.ts",
@@ -68,6 +78,9 @@
 			],
 			"openapi": [
 				"./dist/integrations/openapi.d.ts"
+			],
+			"openapi-json-schema": [
+				"./dist/integrations/openapi-json-schema.d.ts"
 			],
 			"standard-schema": [
 				"./dist/integrations/standard-schema.d.ts"

--- a/src/integrations/openapi-json-schema.ts
+++ b/src/integrations/openapi-json-schema.ts
@@ -1,0 +1,73 @@
+import { statusToPhrase } from "../status.js";
+
+export type JsonSchemaObject = Record<string, unknown>;
+
+export type ProblemDetailsJsonSchema = {
+	title: "ProblemDetails";
+	type: "object";
+	properties: Record<string, JsonSchemaObject>;
+	required: string[];
+};
+
+const STANDARD_FIELD_KEYS = new Set(["type", "status", "title", "detail", "instance"]);
+
+/**
+ * Build the RFC 9457 Problem Details schema as plain JSON Schema
+ * (draft 2020-12, the OpenAPI 3.1 base dialect), for stacks that document
+ * responses without Zod (hono-openapi, Valibot, ArkType, typia, ...).
+ *
+ * Extensions are merged at top level per RFC 9457 §3.1, and **standard fields
+ * always win** over extension keys that collide (mirroring the runtime spread
+ * order in `problemDetails()`). Conflicting extension keys are silently
+ * dropped from the schema. See ADR-0002.
+ *
+ * A fresh object is returned on every call so callers can safely mutate the
+ * result (e.g. append to `required`) without affecting other call sites.
+ */
+export function problemDetailsJsonSchema(options?: {
+	extensions?: Record<string, JsonSchemaObject>;
+}): ProblemDetailsJsonSchema {
+	const properties: Record<string, JsonSchemaObject> = {
+		type: { type: "string", description: "Problem type URI", examples: ["about:blank"] },
+		status: { type: "integer", description: "HTTP status code", examples: [400] },
+		title: {
+			type: "string",
+			description: "Short summary of the problem type",
+			examples: ["Bad Request"],
+		},
+		detail: { type: "string", description: "Human-readable explanation" },
+		instance: { type: "string", description: "URI identifying the occurrence" },
+	};
+	for (const [key, schema] of Object.entries(options?.extensions ?? {})) {
+		if (!STANDARD_FIELD_KEYS.has(key)) {
+			properties[key] = schema;
+		}
+	}
+	return {
+		title: "ProblemDetails",
+		type: "object",
+		properties,
+		required: ["type", "status", "title"],
+	};
+}
+
+/**
+ * Create an OpenAPI response object for Problem Details as plain JSON Schema.
+ * Ready to drop into hono-openapi's describeRoute():
+ * responses: { 422: problemDetailsResponseJsonSchema(422) }
+ */
+export function problemDetailsResponseJsonSchema(
+	status: number,
+	description?: string,
+	schema?: JsonSchemaObject,
+): {
+	content: { "application/problem+json": { schema: JsonSchemaObject } };
+	description: string;
+} {
+	return {
+		content: {
+			"application/problem+json": { schema: schema ?? problemDetailsJsonSchema() },
+		},
+		description: description ?? statusToPhrase(status) ?? "Error",
+	};
+}

--- a/src/integrations/openapi-json-schema.ts
+++ b/src/integrations/openapi-json-schema.ts
@@ -1,4 +1,5 @@
 import { statusToPhrase } from "../status.js";
+import { DANGEROUS_KEYS } from "../utils.js";
 
 export type JsonSchemaObject = Record<string, unknown>;
 
@@ -19,10 +20,12 @@ const STANDARD_FIELD_KEYS = new Set(["type", "status", "title", "detail", "insta
  * Extensions are merged at top level per RFC 9457 §3.1, and **standard fields
  * always win** over extension keys that collide (mirroring the runtime spread
  * order in `problemDetails()`). Conflicting extension keys are silently
- * dropped from the schema. See ADR-0002.
+ * dropped from the schema (see ADR-0002), as are the prototype-pollution
+ * guard keys `sanitizeExtensions` strips from every real response.
  *
- * A fresh object is returned on every call so callers can safely mutate the
- * result (e.g. append to `required`) without affecting other call sites.
+ * A fresh object is returned on every call, with extension schemas cloned,
+ * so callers can safely mutate the result (e.g. append to `required`)
+ * without affecting other call sites or their own input.
  */
 export function problemDetailsJsonSchema(options?: {
 	extensions?: Record<string, JsonSchemaObject>;
@@ -39,8 +42,8 @@ export function problemDetailsJsonSchema(options?: {
 		instance: { type: "string", description: "URI identifying the occurrence" },
 	};
 	for (const [key, schema] of Object.entries(options?.extensions ?? {})) {
-		if (!STANDARD_FIELD_KEYS.has(key)) {
-			properties[key] = schema;
+		if (!STANDARD_FIELD_KEYS.has(key) && !DANGEROUS_KEYS.has(key)) {
+			properties[key] = structuredClone(schema);
 		}
 	}
 	return {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@ import type { ProblemDetails, ProblemDetailsInput } from "./types.js";
 /** RFC 9457 media type: `application/problem+json; charset=utf-8`. */
 export const PROBLEM_JSON_CONTENT_TYPE = "application/problem+json; charset=utf-8";
 
-const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+export const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
 
 /** Strip keys that could cause prototype pollution in downstream consumers */
 export function sanitizeExtensions(

--- a/tests/integrations/openapi-json-schema.test.ts
+++ b/tests/integrations/openapi-json-schema.test.ts
@@ -77,6 +77,30 @@ describe("problemDetailsJsonSchema", () => {
 		expect(second.properties.status).toMatchObject({ type: "integer" });
 		expect(second.required).toEqual(["type", "status", "title"]);
 	});
+
+	it("JS12: does not alias caller-supplied extension schemas", () => {
+		const shared = { type: "array", items: { type: "string" } };
+		const first = problemDetailsJsonSchema({ extensions: { errors: shared } });
+		(first.properties.errors as { items: { type: string } }).items.type = "integer";
+		const second = problemDetailsJsonSchema({ extensions: { errors: shared } });
+		expect(shared.items.type).toBe("string");
+		expect(second.properties.errors).toEqual({ type: "array", items: { type: "string" } });
+	});
+
+	it("JS13: drops extension keys the runtime strips as prototype-pollution guards", () => {
+		const schema = problemDetailsJsonSchema({
+			extensions: {
+				constructor: { type: "string" },
+				prototype: { type: "string" },
+				["__proto__"]: { type: "string" },
+				safe: { type: "string" },
+			},
+		});
+		expect(Object.hasOwn(schema.properties, "constructor")).toBe(false);
+		expect(Object.hasOwn(schema.properties, "prototype")).toBe(false);
+		expect(Object.hasOwn(schema.properties, "__proto__")).toBe(false);
+		expect(schema.properties.safe).toEqual({ type: "string" });
+	});
 });
 
 describe("problemDetailsResponseJsonSchema", () => {

--- a/tests/integrations/openapi-json-schema.test.ts
+++ b/tests/integrations/openapi-json-schema.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import {
+	problemDetailsJsonSchema,
+	problemDetailsResponseJsonSchema,
+} from "../../src/integrations/openapi-json-schema.js";
+
+describe("problemDetailsJsonSchema", () => {
+	it("JS1: has RFC 9457 standard fields with JSON Schema types", () => {
+		const schema = problemDetailsJsonSchema();
+		expect(schema.properties.type).toMatchObject({ type: "string" });
+		expect(schema.properties.status).toMatchObject({ type: "integer" });
+		expect(schema.properties.title).toMatchObject({ type: "string" });
+		expect(schema.properties.detail).toMatchObject({ type: "string" });
+		expect(schema.properties.instance).toMatchObject({ type: "string" });
+	});
+
+	it("JS2: requires exactly type, status, and title", () => {
+		expect(problemDetailsJsonSchema().required).toEqual(["type", "status", "title"]);
+	});
+
+	it("JS3: is an object schema titled ProblemDetails without additionalProperties", () => {
+		const schema = problemDetailsJsonSchema();
+		expect(schema.title).toBe("ProblemDetails");
+		expect(schema.type).toBe("object");
+		expect("additionalProperties" in schema).toBe(false);
+	});
+
+	it("JS4: mirrors the Zod schema descriptions and examples", () => {
+		const { properties } = problemDetailsJsonSchema();
+		expect(properties.type).toMatchObject({
+			description: "Problem type URI",
+			examples: ["about:blank"],
+		});
+		expect(properties.status).toMatchObject({
+			description: "HTTP status code",
+			examples: [400],
+		});
+		expect(properties.title).toMatchObject({
+			description: "Short summary of the problem type",
+			examples: ["Bad Request"],
+		});
+		expect(properties.detail).toMatchObject({ description: "Human-readable explanation" });
+		expect(properties.instance).toMatchObject({
+			description: "URI identifying the occurrence",
+		});
+	});
+
+	it("JS5: merges extensions as top-level optional properties", () => {
+		const schema = problemDetailsJsonSchema({
+			extensions: {
+				conflictingResources: { type: "array", items: { type: "string" } },
+			},
+		});
+		expect(schema.properties.conflictingResources).toEqual({
+			type: "array",
+			items: { type: "string" },
+		});
+		expect(schema.required).toEqual(["type", "status", "title"]);
+	});
+
+	it("JS6: drops extension keys that collide with standard fields", () => {
+		const schema = problemDetailsJsonSchema({
+			extensions: {
+				status: { type: "string" },
+				retryAfter: { type: "integer" },
+			},
+		});
+		expect(schema.properties.status).toMatchObject({ type: "integer" });
+		expect(schema.properties.retryAfter).toEqual({ type: "integer" });
+	});
+
+	it("JS7: returns a fresh object on every call", () => {
+		const first = problemDetailsJsonSchema();
+		first.properties.status = { type: "string" };
+		first.required.push("detail");
+		const second = problemDetailsJsonSchema();
+		expect(second.properties.status).toMatchObject({ type: "integer" });
+		expect(second.required).toEqual(["type", "status", "title"]);
+	});
+});
+
+describe("problemDetailsResponseJsonSchema", () => {
+	it("JS8: wraps the base schema under the problem+json content type", () => {
+		const response = problemDetailsResponseJsonSchema(422);
+		expect(response.description).toBe("Unprocessable Content");
+		expect(response.content["application/problem+json"].schema).toEqual(problemDetailsJsonSchema());
+	});
+
+	it("JS9: uses the provided description over the status phrase", () => {
+		const response = problemDetailsResponseJsonSchema(409, "Slot already taken");
+		expect(response.description).toBe("Slot already taken");
+	});
+
+	it("JS10: falls back to 'Error' for an unknown status", () => {
+		expect(problemDetailsResponseJsonSchema(599).description).toBe("Error");
+	});
+
+	it("JS11: uses the provided schema over the default", () => {
+		const custom = problemDetailsJsonSchema({
+			extensions: { errors: { type: "array" } },
+		});
+		const response = problemDetailsResponseJsonSchema(422, undefined, custom);
+		expect(response.content["application/problem+json"].schema).toBe(custom);
+	});
+});

--- a/tests/type-compat/core-consumer.ts
+++ b/tests/type-compat/core-consumer.ts
@@ -17,7 +17,10 @@ import {
 	getProblemDetailsSchema,
 	problemDetailsResponse,
 } from "../../dist/integrations/openapi.js";
-import type { ProblemDetailsJsonSchema } from "../../dist/integrations/openapi-json-schema.js";
+import type {
+	JsonSchemaObject,
+	ProblemDetailsJsonSchema,
+} from "../../dist/integrations/openapi-json-schema.js";
 import {
 	problemDetailsJsonSchema,
 	problemDetailsResponseJsonSchema,
@@ -88,10 +91,15 @@ const _standardHook = standardSchemaProblemHook();
 const _problemSchema = getProblemDetailsSchema();
 const _problemSchemaFactory = createProblemDetailsSchema;
 const _problemResponse = problemDetailsResponse;
+const _extensionSchema: JsonSchemaObject = { type: "array", items: { type: "string" } };
 const _problemJsonSchema: ProblemDetailsJsonSchema = problemDetailsJsonSchema({
-	extensions: { errors: { type: "array" } },
+	extensions: { errors: _extensionSchema },
 });
-const _problemJsonSchemaResponse = problemDetailsResponseJsonSchema(422);
+const _problemJsonSchemaResponse = problemDetailsResponseJsonSchema(
+	422,
+	undefined,
+	_extensionSchema,
+);
 
 void _ct;
 void _problem;

--- a/tests/type-compat/core-consumer.ts
+++ b/tests/type-compat/core-consumer.ts
@@ -17,6 +17,11 @@ import {
 	getProblemDetailsSchema,
 	problemDetailsResponse,
 } from "../../dist/integrations/openapi.js";
+import type { ProblemDetailsJsonSchema } from "../../dist/integrations/openapi-json-schema.js";
+import {
+	problemDetailsJsonSchema,
+	problemDetailsResponseJsonSchema,
+} from "../../dist/integrations/openapi-json-schema.js";
 import { standardSchemaProblemHook } from "../../dist/integrations/standard-schema.js";
 import { valibotProblemHook } from "../../dist/integrations/valibot.js";
 import { zodProblemHook } from "../../dist/integrations/zod.js";
@@ -83,6 +88,10 @@ const _standardHook = standardSchemaProblemHook();
 const _problemSchema = getProblemDetailsSchema();
 const _problemSchemaFactory = createProblemDetailsSchema;
 const _problemResponse = problemDetailsResponse;
+const _problemJsonSchema: ProblemDetailsJsonSchema = problemDetailsJsonSchema({
+	extensions: { errors: { type: "array" } },
+});
+const _problemJsonSchemaResponse = problemDetailsResponseJsonSchema(422);
 
 void _ct;
 void _problem;
@@ -101,3 +110,5 @@ void _standardHook;
 void _problemSchema;
 void _problemSchemaFactory;
 void _problemResponse;
+void _problemJsonSchema;
+void _problemJsonSchemaResponse;

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
 		"integrations/zod": "src/integrations/zod.ts",
 		"integrations/valibot": "src/integrations/valibot.ts",
 		"integrations/openapi": "src/integrations/openapi.ts",
+		"integrations/openapi-json-schema": "src/integrations/openapi-json-schema.ts",
 		"integrations/standard-schema": "src/integrations/standard-schema.ts",
 	},
 	format: ["esm", "cjs"],


### PR DESCRIPTION
## Overview

Closes #185.

Adds a new subpath export `hono-problem-details/openapi-json-schema` so non-Zod stacks (`hono-openapi` + Valibot / ArkType / typia) can document RFC 9457 Problem Details responses. The existing `./openapi` helpers require `@hono/zod-openapi`, which left Standard-Schema-based stacks with no way to describe problem responses in their generated OpenAPI documents even though the runtime integrations already work there.

## Changes

- `problemDetailsJsonSchema(options?)` — emits the Problem Details schema as plain JSON Schema (draft 2020-12, the OpenAPI 3.1 base dialect), mirroring the field set, descriptions, and examples of the Zod `getProblemDetailsSchema()`. Optional `extensions` merge as top-level properties; keys colliding with standard fields are silently dropped, so standard fields always win (ADR-0002, same rule as `createProblemDetailsSchema` and the runtime spread order). Keys the runtime strips as prototype-pollution guards (`__proto__`, `constructor`, `prototype`) are excluded too, so the schema never documents a member real responses omit.
- `problemDetailsResponseJsonSchema(status, description?, schema?)` — wraps the schema as a ready-to-use OpenAPI response object under `application/problem+json`, mirroring `problemDetailsResponse` including the `statusToPhrase` fallback.
- Zero runtime dependencies: the module only imports from core (`statusToPhrase`, the shared `DANGEROUS_KEYS` guard set).
- Unlike the memoized Zod factory (ADR-0004's bundler constraint does not apply here), every call returns a fresh object with extension schemas cloned, so callers can safely adjust the result without affecting other call sites or their own input.

Wiring: `package.json` `exports`/`typesVersions`, tsup entry, type-compat consumer coverage for the new subpath, README section, and a minor changeset.

## Review guide

| Commit | Scope | Verification |
| --- | --- | --- |
| d0dbb48 | New integration + tests + wiring + docs | `pnpm lint` / `pnpm typecheck` / `pnpm test` / `pnpm build && pnpm test:compat` / `pnpm knip` — all green |
| 7c0db28 | Adversarial-review fixes: clone extension schemas on merge, exclude prototype-pollution guard keys | Same suite re-run green; tests JS12/JS13 pin the fixes (coverage 100% on all metrics, 237 tests) |

Tests JS1–JS13 in `tests/integrations/openapi-json-schema.test.ts` pin the schema shape, extension precedence and isolation, per-call freshness, guard-key exclusion, and the response wrapper defaults.

## Adversarial review

Two independent adversarial passes (JSON-Schema-dialect lens and packaging/test-honesty lens) tried to refute the implementation before merge:

- Withstood: keyword validity for draft 2020-12 (validated with `ajv-cli --spec=draft2020`), extension-precedence parity across the runtime / Zod helpers / this module, hono-openapi `describeRoute` accepting the inline schema object, ESM+CJS subpath resolution via package self-reference, and per-file 100% coverage.
- Refuted and fixed in 7c0db28: caller-supplied extension schemas were stored by reference (a shared schema object leaked mutations across calls), and prototype-pollution guard keys stripped at runtime were still documented in the schema.
- Accepted as-is: `required: ["type", "status", "title"]` is stricter than generic RFC 9457 (where every member is optional), but matches what this library's handler always emits and what the existing Zod schema already declares — the schema documents this library's responses, not arbitrary RFC 9457 documents.

## Notes

- typia was considered as an additional target: it implements Standard Schema v1 (samchon/typia#1500) so the existing runtime hook already covers it, and `typia.json.schemas()` emits OpenAPI 3.1 dialect schemas that can be passed straight into `extensions` — no dedicated integration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PaE27Fp4wMLQD8sk9V5tQX
