### PR TITLE
chore: migrate biome config to 2.5.8 schema

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.8/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",
@@ -9,7 +9,7 @@
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true
+			"preset": "recommended"
 		}
 	},
 	"formatter": {


### PR DESCRIPTION
## Overview

Biome was bumped to 2.5.8 by Dependabot in #186 without the accompanying `biome migrate`, so `biome check` reported two infos on every run: a schema-version mismatch (2.4.14 vs CLI 2.5.8) and the deprecated `rules.recommended` field.

## Changes

Ran `pnpm biome migrate --write`: schema URL updated to 2.5.8 and `rules.recommended: true` replaced with `rules.preset: "recommended"`. Committed as generated, no manual edits.

## Verification

`biome check --diagnostic-level=info` now reports zero infos; `pnpm lint` / `pnpm typecheck` / `pnpm test` (237 passed) all green with no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PaE27Fp4wMLQD8sk9V5tQX